### PR TITLE
ci: verify advertised support (matrix + real test deps), automate releases, and fix metadata

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -8,32 +8,42 @@ on:
 
 jobs:
   quality:
-    name: Code Quality & Tests
+    name: Lint, format & type check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
-
-      - name: Install dependencies
+      - name: Install package with dev tooling
         run: |
           python -m pip install --upgrade pip
-          pip install ruff mypy numpy scipy pytest pytest-cov
-
-      - name: Install package
-        run: pip install -e .
-
+          pip install -e ".[dev]"
       - name: Check formatting with ruff
         run: ruff format --check .
-
       - name: Lint with ruff
         run: ruff check .
-
       - name: Type check with mypy
-        run: mypy freqprob/ tests/
+        run: mypy freqprob/ tests/ scripts/
 
-      - name: Run tests
-        run: pytest tests/ --cov=freqprob --cov-report=term-missing --cov-fail-under=80
+  test:
+    name: Tests (Python ${{ matrix.python-version }} / ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.10', '3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package with test dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[test]"
+      - name: Run tests with coverage
+        run: pytest tests/ --cov=freqprob --cov-report=term-missing --cov-report=xml --cov-fail-under=80

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip
+          pip install build twine
+      - name: Build sdist and wheel
+        run: python -m build
+      - name: Check distribution metadata
+        run: twine check dist/*
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/freqprob/
+    permissions:
+      id-token: write  # PyPI trusted publishing (OIDC); no API token needed
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,31 @@
+# Pre-commit hooks mirroring the CI "quality" job.
+# Install once with:  pre-commit install
+# Run on all files:   pre-commit run --all-files
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.0
+    hooks:
+      # Linter (matches `ruff check .`)
+      - id: ruff
+        args: [--fix]
+      # Formatter (matches `ruff format --check .`)
+      - id: ruff-format
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.14.1
+    hooks:
+      - id: mypy
+        files: ^(freqprob|tests|scripts)/
+        additional_dependencies:
+          - numpy
+          - scipy

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **CI test matrix**: Tests now run across Python 3.10/3.11/3.12 on Linux, macOS, and
+  Windows, matching the platforms and versions advertised in the metadata.
+- **Automated release workflow**: Tag-triggered GitHub Actions workflow that builds and
+  publishes to PyPI via trusted publishing (OIDC), removing the need for stored tokens.
+- **Pre-commit configuration** (`.pre-commit-config.yaml`) mirroring the CI quality gates
+  (ruff lint, ruff format, mypy).
+- **`test` optional-dependency extra**: Lightweight testing dependency set used by the CI
+  test matrix (`pip install -e ".[test]"`); `dev` now includes it.
+
+### Changed
+
+- **CI**: The quality job now installs `.[dev]` so the Hypothesis, NLTK, and scikit-learn
+  test suites actually execute (previously skipped because those dependencies were not
+  installed), and type checking now also covers `scripts/`.
+
+### Fixed
+
+- **Documentation URL** in package metadata pointed to `docs/user_guide.md` (wrong case);
+  corrected to `docs/USER_GUIDE.md`.
+- **Dead code**: Removed the unreachable `HAS_VALIDATION` block in `freqprob/__init__.py`
+  that referenced a removed module.
+
 ## [0.4.0] - 2025-10-04
 
 ### Changed - BREAKING

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ FreqProb provides state-of-the-art smoothing techniques for converting frequency
 ## **Comprehensive & Accurate**
 - **10+ smoothing methods**: From basic Laplace to advanced Kneser-Ney and Simple Good-Turing
 - **Mathematically rigorous**: Implementations validated against reference sources (NLTK, SciPy)
-- **Production-ready**: Extensive testing with 400+ test cases and property-based validation
+- **Production-ready**: Extensive testing with 200+ test cases and property-based validation
 
 ## **High Performance**
 - **Vectorized operations**: Batch processing with NumPy acceleration
@@ -119,7 +119,7 @@ smoothed_dist = freqprob.ELE(observed_frequencies, bins=total_categories)
 ## Quality & Reliability
 
 ### **Rigorous Testing**
-- **400+ test cases** covering edge cases and normal operations
+- **200+ test cases** covering edge cases and normal operations
 - **Property-based testing** with Hypothesis for mathematical correctness
 - **Regression testing** against reference implementations (NLTK, SciPy)
 - **Numerical stability** validation for extreme inputs

--- a/freqprob/__init__.py
+++ b/freqprob/__init__.py
@@ -49,9 +49,6 @@ from .utils import (
 )
 from .vectorized import BatchScorer, VectorizedScorer, create_vectorized_batch_scorer
 
-# Validation module was removed - use pytest tests instead
-HAS_VALIDATION = False
-
 # Build the namespace
 __all__ = [
     "ELE",
@@ -96,16 +93,3 @@ __all__ = [
     "perplexity",
     "word_frequency",
 ]
-
-# Add validation tools to __all__ if available
-if HAS_VALIDATION:
-    __all__ += [
-        "BenchmarkSuite",
-        "PerformanceMetrics",
-        "PerformanceProfiler",
-        "ValidationResult",
-        "ValidationSuite",
-        "compare_method_performance",
-        "profile_method_performance",
-        "quick_validate_method",
-    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,15 @@ dependencies = [
 memory = [
     "psutil>=5.8.0",
 ]
+# Testing dependencies (lightweight; used by the CI test matrix)
+test = [
+    "pytest>=7.0.0",
+    "pytest-cov>=4.0.0",
+    "pytest-xdist>=3.0.0",
+    "hypothesis>=6.0.0",
+    "nltk>=3.8",
+    "scikit-learn>=1.0.0",
+]
 # All optional dependencies (runtime + development)
 all = [
     "freqprob[memory,dev]",
@@ -50,12 +59,7 @@ all = [
 # Development dependencies
 dev = [
     # Testing (required by Makefile and tests/)
-    "pytest>=7.0.0",
-    "pytest-cov>=4.0.0",
-    "pytest-xdist>=3.0.0",
-    "hypothesis>=6.0.0",
-    "nltk>=3.8",
-    "scikit-learn>=1.0.0",
+    "freqprob[test]",
 
     # Code quality (required by Makefile)
     "ruff>=0.1.0",
@@ -73,7 +77,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/tresoldi/freqprob"
-Documentation = "https://github.com/tresoldi/freqprob/blob/main/docs/user_guide.md"
+Documentation = "https://github.com/tresoldi/freqprob/blob/main/docs/USER_GUIDE.md"
 Repository = "https://github.com/tresoldi/freqprob.git"
 Issues = "https://github.com/tresoldi/freqprob/issues"
 Changelog = "https://github.com/tresoldi/freqprob/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary

This PR aligns the project's CI and metadata with what it advertises, and adds release automation. The library code is unchanged except for removing dead code — the focus is closing the gap between claimed and enforced quality.

## Motivation

While reviewing the project I found several places where the advertised guarantees weren't actually being verified:

- **CI ran only Python 3.12 on Ubuntu**, yet the package targets 3.10–3.12 and the README claims *"Cross-platform testing on Linux, Windows, and macOS."*
- **The Hypothesis, NLTK, and scikit-learn test suites were silently skipped in CI** — those tests skip gracefully when their imports are missing, and CI installed only `ruff mypy numpy scipy pytest pytest-cov`. So the prominently-advertised property-based and reference-regression testing never ran.
- Releases were fully manual (`Makefile` → `twine`).

## Changes

### CI (`quality.yml`)
- Split into a `quality` job (lint/format/type-check) and a `test` job.
- `test` runs a matrix over **Python 3.10/3.11/3.12 × Linux/macOS/Windows**.
- Installs the package with its test dependencies (`pip install -e ".[test]"`) so the Hypothesis / NLTK / scikit-learn suites actually execute.
- Type checking now also covers `scripts/` (matching `make quality`).

### Release automation (`release.yml`, new)
- Tag-triggered (`v*`) build of sdist + wheel, `twine check`, then publish to PyPI via **trusted publishing (OIDC)** — no stored tokens.
- **Requires one-time setup**: add `tresoldi/freqprob` as a trusted publisher on PyPI (workflow `release.yml`, environment `pypi`) before pushing a release tag.

### Packaging & metadata
- Added a lightweight `test` optional-dependency extra for fast CI installs; `dev` now includes it.
- Fixed the `Documentation` URL in package metadata (`docs/user_guide.md` → `docs/USER_GUIDE.md`; the wrong casing was a 404).

### Cleanup
- Removed the unreachable `HAS_VALIDATION` block in `freqprob/__init__.py` (referenced a removed module; could never execute).
- Corrected the overstated "400+ test cases" claims in the README to "200+" (actual: 223 test functions).

### Developer experience
- Added `.pre-commit-config.yaml` mirroring the CI quality gates (ruff lint, ruff format, mypy).

## Verification

Locally, all gates pass on the branch:

- `ruff format --check .` — clean
- `ruff check .` — clean
- `mypy freqprob/ tests/ scripts/` — no issues (23 source files)
- `pytest tests/ --cov=freqprob --cov-fail-under=80` — **229 passed, 5 skipped, 83.62% coverage**

Note: this is the first time the suite runs on macOS and Windows, so those matrix legs are the ones to watch on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_