### PR TITLE
chore: add governance files, Codecov config, and a bandit security target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (ruff lint, ruff format, mypy).
 - **`test` optional-dependency extra**: Lightweight testing dependency set used by the CI
   test matrix (`pip install -e ".[test]"`); `dev` now includes it.
+- **`CITATION.cff`**: Machine-readable citation metadata, enabling GitHub's native
+  "Cite this repository" support.
+- **`CONTRIBUTING.md`** and **`SECURITY.md`**: Contributor setup/quality-check guide and
+  a vulnerability reporting policy.
+- **Codecov integration**: `codecov.yml` configuration and a coverage badge in the README.
+- **`make security` target**: Runs the (already configured) `bandit` static security
+  analysis; `bandit[toml]` added to the `dev` extra.
 
 ### Changed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it using the metadata from this file."
+title: "FreqProb: A Python library for probability smoothing and frequency-based language modeling"
+abstract: >-
+  FreqProb is a Python library for scoring observation probabilities from
+  frequency counts, providing a range of smoothing methods (from Laplace and
+  Lidstone to Simple Good-Turing and Kneser-Ney) for natural language
+  processing, information retrieval, and statistical modeling.
+type: software
+authors:
+  - family-names: Tresoldi
+    given-names: Tiago
+    affiliation: "Department of Linguistics and Philology, Uppsala University"
+    email: tiago.tresoldi@lingfil.uu.se
+version: 0.4.0
+license: MIT
+repository-code: "https://github.com/tresoldi/freqprob"
+url: "https://github.com/tresoldi/freqprob"
+keywords:
+  - nlp
+  - smoothing
+  - frequency
+  - probability
+  - language-model

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,71 @@
+# Contributing to FreqProb
+
+Thanks for your interest in improving FreqProb! This document explains how to
+set up a development environment and the checks your changes are expected to
+pass.
+
+## Development setup
+
+FreqProb requires Python 3.10 or newer.
+
+```bash
+# Clone your fork and enter the directory
+git clone https://github.com/<your-username>/freqprob.git
+cd freqprob
+
+# Install the package with all development dependencies
+pip install -e ".[dev]"
+
+# (Optional but recommended) install the pre-commit hooks
+pre-commit install
+```
+
+Installing with the `dev` extra pulls in everything the test suite and the
+tooling need: `pytest`, `hypothesis`, `nltk`, `scikit-learn`, `ruff`, `mypy`,
+`bandit`, `build`, and the documentation tools. If you only want to run the
+tests, the lighter `pip install -e ".[test]"` is enough.
+
+## Quality checks
+
+All of the checks below run in CI. You can run them locally through the
+`Makefile` targets:
+
+```bash
+make quality   # ruff format --check, ruff check, mypy
+make security  # bandit static security analysis
+make test      # run the test suite
+make test-cov  # run the test suite with a coverage report (fails under 80%)
+```
+
+Or invoke the tools directly:
+
+```bash
+ruff format --check .
+ruff check .
+mypy freqprob/ tests/ scripts/
+bandit -c pyproject.toml -r freqprob/
+pytest tests/ --cov=freqprob --cov-fail-under=80
+```
+
+If you installed the pre-commit hooks, `ruff`, `ruff format`, `mypy`, and
+`bandit` also run automatically on every commit.
+
+## Making changes
+
+1. Create a feature branch off `main`.
+2. Make your change, adding or updating tests to cover it. New behavior should
+   keep overall coverage at or above 80%.
+3. Update `CHANGELOG.md` under the `[Unreleased]` section.
+4. Ensure `make quality`, `make security`, and `make test-cov` all pass.
+5. Open a pull request describing the motivation and the change.
+
+## Reporting bugs and requesting features
+
+Please use the [issue tracker](https://github.com/tresoldi/freqprob/issues).
+For bug reports, include a minimal reproducible example, the FreqProb version,
+and your Python version.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+MIT License that covers the project.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # FreqProb Makefile
 # POSIX-compatible development commands
 
-.PHONY: help quality format test test-cov test-fast bump-version build build-release clean install install-dev bench bench-all docs docs-clean
+.PHONY: help quality security format test test-cov test-fast bump-version build build-release clean install install-dev bench bench-all docs docs-clean
 
 # Default target: show help
 .DEFAULT_GOAL := help
@@ -33,6 +33,11 @@ quality: ## Run code quality checks (ruff format --check, ruff check, mypy)
 	@echo "==> Running mypy type checker..."
 	mypy freqprob/ tests/ scripts/
 	@echo "✓ All quality checks passed!"
+
+security: ## Run bandit static security analysis
+	@echo "==> Running bandit security scan..."
+	bandit -c pyproject.toml -r freqprob/
+	@echo "✓ Security scan passed!"
 
 format: ## Auto-format code with ruff
 	@echo "==> Formatting code with ruff..."

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FreqProb
 
 [![CI](https://github.com/tresoldi/freqprob/actions/workflows/quality.yml/badge.svg)](https://github.com/tresoldi/freqprob/actions/workflows/quality.yml)
+[![codecov](https://codecov.io/gh/tresoldi/freqprob/branch/main/graph/badge.svg)](https://codecov.io/gh/tresoldi/freqprob)
 [![PyPI version](https://badge.fury.io/py/freqprob.svg)](https://badge.fury.io/py/freqprob)
 [![Python versions](https://img.shields.io/pypi/pyversions/freqprob.svg)](https://pypi.org/project/freqprob/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Supported versions
+
+FreqProb is under active development. Security fixes are applied to the latest
+released version on PyPI. Please make sure you are running the most recent
+release before reporting an issue.
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 0.4.x   | :white_check_mark: |
+| < 0.4   | :x:                |
+
+## Reporting a vulnerability
+
+If you believe you have found a security vulnerability, please report it
+privately rather than opening a public issue.
+
+- Use GitHub's [private vulnerability reporting](https://github.com/tresoldi/freqprob/security/advisories/new)
+  (Security → Report a vulnerability), or
+- Email the maintainer at tiago.tresoldi@lingfil.uu.se.
+
+Please include a description of the issue, the affected version(s), and, if
+possible, a minimal reproduction. You can expect an initial acknowledgement
+within a reasonable timeframe, and we will keep you informed as the report is
+investigated and resolved.
+
+Because FreqProb is a numerical/NLP library with no network or authentication
+surface, the most likely concerns are around untrusted input (for example,
+deserializing data or processing adversarial frequency distributions). Reports
+in those areas are especially welcome.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,24 @@
+# Codecov configuration
+# https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  status:
+    project:
+      default:
+        # Allow a small drop so unrelated line-count changes don't fail PRs.
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        # New/changed lines should be reasonably well covered.
+        target: 80%
+        threshold: 5%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "tests/**"
+  - "scripts/**"
+  - "docs/**"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,7 @@ dev = [
     # Code quality (required by Makefile)
     "ruff>=0.1.0",
     "mypy>=1.5.0",
+    "bandit[toml]>=1.7.0",
 
     # Build and release (required by Makefile)
     "build>=0.10.0",


### PR DESCRIPTION
## Summary

Follow-up project-hygiene improvements after the CI/release PR (#14). No library code changes — this adds standard community/health files, coverage reporting config, and wires up the already-configured static security scan.

## Changes

### Governance / community health
- **`CITATION.cff`** — machine-readable citation metadata (author, affiliation, version, keywords) so GitHub surfaces its native "Cite this repository" button. Mirrors the BibTeX already in the README.
- **`CONTRIBUTING.md`** — development setup (`pip install -e ".[dev]"`, `pre-commit install`), the quality/security/test commands, and the PR workflow.
- **`SECURITY.md`** — supported versions and a private vulnerability-reporting policy (GitHub advisories + maintainer email).

### Coverage reporting
- **`codecov.yml`** — project target `auto` with a 1% threshold, 80% target on patch coverage, and `tests/`/`scripts/`/`docs/` ignored.
- **README** — added a Codecov coverage badge.

### Security scanning
- **`make security`** — runs `bandit -c pyproject.toml -r freqprob/`, activating the `[tool.bandit]` config that was already present but never invoked.
- **`pyproject.toml`** — added `bandit[toml]` to the `dev` extra.

### Docs
- **`CHANGELOG.md`** — documented all of the above under `[Unreleased]`.

## Verification

- `ruff check .` and `ruff format --check .` — clean
- `make security` — passes, 0 issues (High/Medium: 0)
- `codecov.yml` and `CITATION.cff` — valid YAML

## Follow-up (not in this PR — require workflow-file edits)

Two optional wiring steps were intentionally left out because they modify `.github/workflows/quality.yml`:

- Uploading coverage to Codecov in CI (`codecov/codecov-action@v5` step). The badge will read "unknown" until the repo is enabled on codecov.io and coverage is uploaded.
- Running `bandit` as a CI gate (currently available via `make security` and locally).

> Note: the architecture anchor doc that briefly appeared here has been split into its own PR to keep this one focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)