### PR TITLE
refactor: collapse redundant per-method config dataclasses (Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Collapsed redundant configuration classes**: Removed eight per-method `*Config`
+  dataclasses that only restated fields already defined on the base
+  `ScoringMethodConfig` (`UniformConfig`, `MLEConfig`, `LidstoneConfig`,
+  `LaplaceConfig`, `ELEConfig`, `WittenBellConfig`, `CertaintyDegreeConfig`,
+  `ModifiedKneserNeyConfig` — the last three of which were never even instantiated).
+  Those methods now build the base `ScoringMethodConfig` directly. The five configs
+  that add a genuine parameter are kept but trimmed to just that field
+  (`RandomConfig.seed`, `KneserNeyConfig.discount`, `BayesianConfig.alpha`,
+  `InterpolatedConfig.lambda_weight`, `SimpleGoodTuringConfig.p_value`/`default_p0`/
+  `allow_fail`). No public API or behavior change — all constructor parameters work
+  exactly as before.
+
 - **mypy target**: Set mypy `python_version` to `3.12` so it can parse modern
   dependency stubs (e.g. numpy's PEP 695 `type` statements). Source-level 3.10
   compatibility is still enforced by ruff (`target-version = "py310"`) and validated

--- a/src/freqprob/methods/additive.py
+++ b/src/freqprob/methods/additive.py
@@ -7,63 +7,8 @@ counts to observed data to handle the zero probability problem.
 """
 
 import math
-from dataclasses import dataclass
 
 from freqprob.base import FrequencyDistribution, ScoringMethod, ScoringMethodConfig
-
-
-@dataclass
-class LidstoneConfig(ScoringMethodConfig):
-    """Configuration for Lidstone smoothing.
-
-    Attributes:
-    ----------
-    gamma : float
-        Additive smoothing parameter (gamma ≥ 0, default: 1.0)
-    bins : int | None
-        Total number of possible bins/elements (default: vocabulary size)
-    logprob : bool
-        Whether to return log-probabilities (default: True)
-    """
-
-    gamma: float = 1.0
-
-    bins: int | None = None
-    logprob: bool = True
-
-
-@dataclass
-class LaplaceConfig(ScoringMethodConfig):
-    """Configuration for Laplace smoothing (Lidstone with gamma=1).
-
-    Attributes:
-    ----------
-    bins : int | None
-        Total number of possible bins/elements (default: vocabulary size)
-    logprob : bool
-        Whether to return log-probabilities (default: True)
-    """
-
-    bins: int | None = None
-
-    logprob: bool = True
-
-
-@dataclass
-class ELEConfig(ScoringMethodConfig):
-    """Configuration for Expected Likelihood Estimation (Lidstone with gamma=0.5).
-
-    Attributes:
-    ----------
-    bins : int | None
-        Total number of possible bins/elements (default: vocabulary size)
-    logprob : bool
-        Whether to return log-probabilities (default: True)
-    """
-
-    bins: int | None = None
-
-    logprob: bool = True
 
 
 class Lidstone(ScoringMethod):
@@ -162,7 +107,7 @@ class Lidstone(ScoringMethod):
         if bins is None:
             bins = len(freqdist)
 
-        config = LidstoneConfig(gamma=gamma, bins=bins, logprob=logprob)
+        config = ScoringMethodConfig(gamma=gamma, bins=bins, logprob=logprob)
         super().__init__(config)
         self.name = "Lidstone"
         self.fit(freqdist)
@@ -179,8 +124,8 @@ class Lidstone(ScoringMethod):
         bins = self.config.bins
 
         # Ensure gamma and bins are not None (they are set in __init__)
-        assert gamma is not None, "Gamma must be set in LidstoneConfig"
-        assert bins is not None, "Bins must be set in LidstoneConfig"
+        assert gamma is not None, "Gamma must be set before computing probabilities"
+        assert bins is not None, "Bins must be set before computing probabilities"
 
         # Calculate normalization factors
         total_count = sum(freqdist.values())

--- a/src/freqprob/methods/baselines.py
+++ b/src/freqprob/methods/baselines.py
@@ -14,23 +14,6 @@ from freqprob.base import FrequencyDistribution, Probability, ScoringMethod, Sco
 
 
 @dataclass
-class UniformConfig(ScoringMethodConfig):
-    """Configuration for Uniform distribution.
-
-    Attributes:
-    ----------
-    unobs_prob : Probability
-        Reserved probability mass for unobserved elements (default: 0.0)
-    logprob : bool
-        Whether to return log-probabilities (default: True)
-    """
-
-    unobs_prob: Probability = 0.0
-
-    logprob: bool = True
-
-
-@dataclass
 class RandomConfig(ScoringMethodConfig):
     """Configuration for Random distribution.
 
@@ -44,27 +27,7 @@ class RandomConfig(ScoringMethodConfig):
         Random seed for reproducible results (default: None)
     """
 
-    unobs_prob: Probability = 0.0
-
-    logprob: bool = True
     seed: int | None = None
-
-
-@dataclass
-class MLEConfig(ScoringMethodConfig):
-    """Configuration for Maximum Likelihood Estimation.
-
-    Attributes:
-    ----------
-    unobs_prob : Probability
-        Reserved probability mass for unobserved elements (default: 0.0)
-    logprob : bool
-        Whether to return log-probabilities (default: True)
-    """
-
-    unobs_prob: Probability = 0.0
-
-    logprob: bool = True
 
 
 class Uniform(ScoringMethod):
@@ -126,7 +89,7 @@ class Uniform(ScoringMethod):
         logprob: bool = True,
     ) -> None:
         """Initialize Uniform distribution."""
-        config = UniformConfig(unobs_prob=unobs_prob, logprob=logprob)
+        config = ScoringMethodConfig(unobs_prob=unobs_prob, logprob=logprob)
         super().__init__(config)
         self.name = "Uniform"
         self.fit(freqdist)
@@ -339,7 +302,7 @@ class MLE(ScoringMethod):
         logprob: bool = True,
     ) -> None:
         """Initialize MLE distribution."""
-        config = MLEConfig(unobs_prob=unobs_prob, logprob=logprob)
+        config = ScoringMethodConfig(unobs_prob=unobs_prob, logprob=logprob)
         super().__init__(config)
         self.name = "MLE"
         self.fit(freqdist)

--- a/src/freqprob/methods/bayesian.py
+++ b/src/freqprob/methods/bayesian.py
@@ -24,8 +24,6 @@ class BayesianConfig(ScoringMethodConfig):
 
     alpha: float = 1.0
 
-    logprob: bool = True
-
 
 class BayesianSmoothing(ScoringMethod):
     """Bayesian smoothing with Dirichlet prior.

--- a/src/freqprob/methods/certainty.py
+++ b/src/freqprob/methods/certainty.py
@@ -1,30 +1,9 @@
 """Certainty-degree probability estimation."""
 
 import math
-from dataclasses import dataclass
 
 from freqprob.base import FrequencyDistribution, Probability, ScoringMethod, ScoringMethodConfig
 from freqprob.cache import cached_computation
-
-
-@dataclass
-class CertaintyDegreeConfig(ScoringMethodConfig):
-    """Configuration for Certainty Degree estimation.
-
-    Attributes:
-    ----------
-    bins : int | None
-        Total number of possible bins/elements (default: vocabulary size)
-    unobs_prob : Probability
-        Reserved probability mass for unobserved elements (default: 0.0)
-    logprob : bool
-        Whether to return log-probabilities (default: True)
-    """
-
-    bins: int | None = None
-
-    unobs_prob: Probability = 0.0
-    logprob: bool = True
 
 
 class CertaintyDegree(ScoringMethod):
@@ -67,7 +46,7 @@ class CertaintyDegree(ScoringMethod):
         logprob: bool = True,
     ) -> None:
         """Initialize Certainty Degree estimation."""
-        config = CertaintyDegreeConfig(bins=bins, unobs_prob=unobs_prob, logprob=logprob)
+        config = ScoringMethodConfig(bins=bins, unobs_prob=unobs_prob, logprob=logprob)
         super().__init__(config)
         self.name = "Certainty Degree"
         self.fit(freqdist)

--- a/src/freqprob/methods/goodturing.py
+++ b/src/freqprob/methods/goodturing.py
@@ -12,23 +12,6 @@ from freqprob.base import FrequencyDistribution, ScoringMethod, ScoringMethodCon
 from freqprob.cache import cached_computation, cached_sgt_computation
 
 
-@dataclass
-class WittenBellConfig(ScoringMethodConfig):
-    """Configuration for Witten-Bell smoothing.
-
-    Attributes:
-    ----------
-    bins : int | None
-        Total number of possible bins/elements (default: vocabulary size)
-    logprob : bool
-        Whether to return log-probabilities (default: True)
-    """
-
-    bins: int | None = None
-
-    logprob: bool = True
-
-
 class WittenBell(ScoringMethod):
     """Returns a Witten-Bell estimate probability distribution.
 
@@ -68,7 +51,7 @@ class WittenBell(ScoringMethod):
         logprob: bool = True,
     ) -> None:
         """Initialize Witten-Bell smoothing."""
-        config = WittenBellConfig(bins=bins, logprob=logprob)
+        config = ScoringMethodConfig(bins=bins, logprob=logprob)
         super().__init__(config)
         self.name = "Witten-Bell"
         self.fit(freqdist)
@@ -120,8 +103,6 @@ class SimpleGoodTuringConfig(ScoringMethodConfig):
     p_value: float = 0.05
 
     default_p0: float | None = None
-    bins: int | None = None
-    logprob: bool = True
     allow_fail: bool = True
 
 

--- a/src/freqprob/methods/interpolated.py
+++ b/src/freqprob/methods/interpolated.py
@@ -27,8 +27,6 @@ class InterpolatedConfig(ScoringMethodConfig):
 
     lambda_weight: float = 0.7
 
-    logprob: bool = True
-
 
 class InterpolatedSmoothing(ScoringMethod):
     """Linear interpolation smoothing between multiple models.

--- a/src/freqprob/methods/kneser_ney.py
+++ b/src/freqprob/methods/kneser_ney.py
@@ -26,8 +26,6 @@ class KneserNeyConfig(ScoringMethodConfig):
 
     discount: float = 0.75
 
-    logprob: bool = True
-
 
 class KneserNey(ScoringMethod):
     """Kneser-Ney smoothing probability distribution.
@@ -185,19 +183,6 @@ class KneserNey(ScoringMethod):
             self._unobs = avg_continuation
 
 
-@dataclass
-class ModifiedKneserNeyConfig(ScoringMethodConfig):
-    """Configuration for Modified Kneser-Ney smoothing.
-
-    Attributes:
-    ----------
-    logprob : bool
-        Whether to return log-probabilities (default: True)
-    """
-
-    logprob: bool = True
-
-
 class ModifiedKneserNey(ScoringMethod):
     """Modified Kneser-Ney smoothing probability distribution.
 
@@ -258,7 +243,7 @@ class ModifiedKneserNey(ScoringMethod):
 
     def __init__(self, freqdist: FrequencyDistribution, logprob: bool = True) -> None:
         """Initialize Modified Kneser-Ney smoothing."""
-        config = ModifiedKneserNeyConfig(logprob=logprob)
+        config = ScoringMethodConfig(logprob=logprob)
         super().__init__(config)
         self.name = "Modified Kneser-Ney"
         self.fit(freqdist)


### PR DESCRIPTION
## Summary

Phase 3 of the architectural revision (`ARCHITECTURE.md` §4). Removes the per-method `*Config` boilerplate. **No public API or behavior change** — every constructor parameter works exactly as before; this is an internal DRY cleanup. Net **−139 lines**.

## What changed

The base `ScoringMethodConfig` already defines `unobs_prob`, `gamma`, `bins`, `logprob` (with validation). Many per-method configs merely restated a subset of those fields, adding nothing.

**Removed 8 boilerplate configs** — those methods now build the base `ScoringMethodConfig` directly:

| Removed config | Method | Note |
|----------------|--------|------|
| `UniformConfig` | `Uniform` | only restated base fields |
| `MLEConfig` | `MLE` | only restated base fields |
| `LidstoneConfig` | `Lidstone` | only restated base fields |
| `LaplaceConfig` | `Laplace` | **never instantiated** (Laplace routes through `Lidstone.__init__`) |
| `ELEConfig` | `ELE` | **never instantiated** (same) |
| `WittenBellConfig` | `WittenBell` | only restated base fields |
| `CertaintyDegreeConfig` | `CertaintyDegree` | only restated base fields |
| `ModifiedKneserNeyConfig` | `ModifiedKneserNey` | only restated `logprob` |

**Kept 5 configs** that add a genuine parameter — trimmed to just the novel field(s), dropping redundant re-declarations of inherited base fields:

- `RandomConfig` → `seed`
- `KneserNeyConfig` → `discount`
- `BayesianConfig` → `alpha`
- `InterpolatedConfig` → `lambda_weight`
- `SimpleGoodTuringConfig` → `p_value`, `default_p0`, `allow_fail`

## Verification (local)

- `ruff check` / `ruff format --check` — clean · `mypy` — clean (29 files)
- `pytest` — **229 passed, 5 skipped, 83.40% coverage** (statement count 1791 → 1759)
- Spot-checked that `discount` / `alpha` / `seed` still take effect and base-config methods (`Laplace`) are unchanged.

## Depends on

Builds on the `methods/` layout from #18 (merged). This is the last of the namespace-preserving phases; the remaining work (docs site + README, and the naming/terminology → 1.0.0 pass) touches the public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_