### PR TITLE
docs: add MkDocs site and rewrite the README (Phase 4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -196,3 +196,6 @@ docs/*.out.html
 # Generated documentation artifacts (built in CI, not committed)
 docs/tutorial_*.html
 docs/figures/
+
+# MkDocs build output
+site/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Documentation site** (MkDocs-Material + mkdocstrings): `mkdocs.yml`, a landing
+  page, and an API reference generated from docstrings (so it can't drift from the
+  code). Build with `make site` / preview with `make site-serve`; a new `docs` extra
+  provides the toolchain. Intended to be published to GitHub Pages.
+
 ### Changed
+
+- **README**: Rewritten to lead with the core value (counts → probabilities) and a
+  single motivating example, add a method-selection table, frame the library as
+  general-purpose (not NLP-only), and collapse the previously repeated testing
+  sections. Documentation links now point to the docs site.
 
 - **Collapsed redundant configuration classes**: Removed eight per-method `*Config`
   dataclasses that only restated fields already defined on the base

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # FreqProb Makefile
 # POSIX-compatible development commands
 
-.PHONY: help quality security format test test-cov test-fast bump-version build build-release clean install install-dev bench bench-all docs docs-clean
+.PHONY: help quality security format test test-cov test-fast bump-version build build-release clean install install-dev bench bench-all docs docs-clean site site-serve
 
 # Default target: show help
 .DEFAULT_GOAL := help
@@ -142,3 +142,12 @@ docs-clean: ## Remove generated HTML documentation
 	@echo "==> Cleaning generated documentation..."
 	rm -f docs/tutorial_*.html
 	@echo "✓ Documentation cleaned!"
+
+site: ## Build the MkDocs documentation site (strict) into site/
+	@echo "==> Building documentation site..."
+	mkdocs build --strict
+	@echo "✓ Site built in site/"
+
+site-serve: ## Serve the docs site locally with live reload
+	@echo "==> Serving docs at http://127.0.0.1:8000 ..."
+	mkdocs serve

--- a/README.md
+++ b/README.md
@@ -2,164 +2,90 @@
 
 [![CI](https://github.com/tresoldi/freqprob/actions/workflows/quality.yml/badge.svg)](https://github.com/tresoldi/freqprob/actions/workflows/quality.yml)
 [![codecov](https://codecov.io/gh/tresoldi/freqprob/branch/main/graph/badge.svg)](https://codecov.io/gh/tresoldi/freqprob)
+[![Docs](https://img.shields.io/badge/docs-mkdocs-blue.svg)](https://tresoldi.github.io/freqprob/)
 [![PyPI version](https://badge.fury.io/py/freqprob.svg)](https://badge.fury.io/py/freqprob)
 [![Python versions](https://img.shields.io/pypi/pyversions/freqprob.svg)](https://pypi.org/project/freqprob/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000.svg)](https://github.com/astral-sh/ruff)
 
-**A modern, high-performance Python library for probability smoothing and frequency-based language modeling.**
+**Turn frequency counts into probability estimates.**
 
-FreqProb provides state-of-the-art smoothing techniques for converting frequency counts into probability estimates, with applications in natural language processing, information retrieval, and statistical modeling.
+FreqProb converts a mapping of elements to observed counts into smoothed
+probabilities that handle unseen elements sensibly. It's a general-purpose
+statistical tool — natural language processing is one consumer among many
+(information retrieval, ecology, genomics, categorical analytics, ML features).
 
-## **Comprehensive & Accurate**
-- **10+ smoothing methods**: From basic Laplace to advanced Kneser-Ney and Simple Good-Turing
-- **Mathematically rigorous**: Implementations validated against reference sources (NLTK, SciPy)
-- **Production-ready**: Extensive testing with 200+ test cases and property-based validation
+```python
+import freqprob
 
-## **High Performance**
-- **Vectorized operations**: Batch processing with NumPy acceleration
-- **Memory efficient**: Compressed representations and streaming algorithms  
-- **Lazy evaluation**: Compute probabilities only when needed
-- **Caching system**: Intelligent memoization for expensive operations
+counts = {"the": 100, "cat": 50, "dog": 30, "bird": 10}
 
-## **Developer Experience**
-- **Type safety**: Full type hints with mypy validation
-- **Modern Python**: Requires Python 3.10+, uses latest language features
-- **Rich documentation**: Mathematical background, tutorials, and API reference
-- **Easy integration**: Clean, intuitive API design
+laplace = freqprob.Laplace(counts, bins=10_000, logprob=False)
+laplace("cat")       # 0.0050  — an observed element
+laplace("elephant")  # 0.0001  — an unseen element still gets non-zero mass
+```
 
-## Quick Start
+That last line is the whole point: a raw relative-frequency estimate would
+assign probability **0** to `"elephant"` and break any model that multiplies or
+takes logs of probabilities. Smoothing reserves a bit of mass for what you
+haven't seen yet — and FreqProb gives you a dozen well-tested ways to do it
+behind one consistent interface.
 
-### Installation
+## Install
 
 ```bash
 pip install freqprob
 ```
 
-For additional features:
-```bash
-pip install freqprob[all]  # All optional dependencies
-```
+## The interface
 
-### Basic Usage
+Every estimator follows the same contract: construct it with a frequency
+distribution, then **call it** to score an element.
 
 ```python
-import freqprob
+scorer = freqprob.KneserNey(bigram_counts, discount=0.75)
+scorer(("the", "cat"))          # log-probability of a bigram
 
-# Create a frequency distribution
-word_counts = {'the': 100, 'cat': 50, 'dog': 30, 'bird': 10}
-
-# Basic smoothing - handles zero probabilities
-laplace = freqprob.Laplace(word_counts, bins=10000)
-print(f"P(cat) = {laplace('cat'):.4f}")      # 0.0053
-print(f"P(elephant) = {laplace('elephant'):.6f}")  # 0.000105 (unseen word)
-
-# Advanced smoothing for n-gram models
-bigrams = {('the', 'cat'): 25, ('the', 'dog'): 20, ('a', 'cat'): 15}
-kneser_ney = freqprob.KneserNey(bigrams, discount=0.75)
-
-# Model evaluation
-test_data = ['cat', 'dog', 'bird'] * 10
-perplexity = freqprob.perplexity(laplace, test_data)
-print(f"Perplexity: {perplexity:.2f}")
+# Evaluate a model
+freqprob.perplexity(scorer, test_bigrams)
 ```
 
-## Smoothing Methods
+## Choosing a method
 
-### Basic Methods
-- **MLE (Maximum Likelihood)**: Unsmoothed relative frequencies
-- **Laplace (Add-One)**: Classic add-one smoothing
-- **Lidstone (Add-k)**: Generalized additive smoothing
-- **ELE (Expected Likelihood)**: Lidstone with γ=0.5
+| Method | Use it for | Key parameter |
+|--------|------------|---------------|
+| `MLE` | raw relative frequencies (no smoothing) | — |
+| `Laplace` / `Lidstone` / `ELE` | simple, robust additive smoothing | `bins`, `gamma` |
+| `SimpleGoodTuring` | heavy-tailed count data (many rare items) | `p_value` |
+| `KneserNey` / `ModifiedKneserNey` | n-gram language models | `discount` |
+| `BayesianSmoothing` | Dirichlet-prior smoothing | `alpha` |
+| `InterpolatedSmoothing` | combining models of different orders | `lambda_weight` |
+| `WittenBell`, `CertaintyDegree`, `Uniform`, `Random` | baselines & specialized cases | — |
 
-### Advanced Methods  
-- **Simple Good-Turing**: Frequency-of-frequency based smoothing
-- **Kneser-Ney**: State-of-the-art for n-gram language models
-- **Modified Kneser-Ney**: Improved version with automatic parameter estimation
-- **Bayesian**: Dirichlet prior-based smoothing
-- **Interpolated**: Linear combination of multiple models
+For large or streaming data, FreqProb also provides vectorized batch scoring,
+lazy evaluation, streaming (incremental) estimators, and memory-efficient
+compressed/sparse representations.
 
-### Specialized Features
-- **Streaming algorithms**: Real-time updates for large datasets
-- **Memory optimization**: Compressed and sparse representations
-- **Performance profiling**: Built-in benchmarking and validation tools
+## Why FreqProb
 
-## Use Cases
+- **One consistent API** across a dozen smoothing methods — swap estimators
+  without rewriting your code.
+- **Mathematically validated** against reference implementations (NLTK, SciPy)
+  and checked with property-based tests.
+- **Typed and production-ready** — full type hints (`py.typed`), strict linting
+  and type-checking, and a test suite run across Python 3.10–3.12 on Linux,
+  macOS, and Windows.
 
-### **Natural Language Processing**
-```python
-# Language modeling
-bigrams = freqprob.ngram_frequency(tokens, n=2)
-lm = freqprob.KneserNey(bigrams, discount=0.75)
+## Documentation
 
-# Text classification with smoothed features
-doc_features = freqprob.word_frequency(document_tokens)
-classifier_probs = freqprob.Laplace(doc_features, bins=vocab_size)
-```
-
-### **Information Retrieval**
-```python
-# Document scoring with term frequency smoothing
-term_counts = compute_term_frequencies(document)
-smoothed_tf = freqprob.BayesianSmoothing(term_counts, alpha=0.5)
-
-# Query likelihood with unseen term handling
-query_prob = sum(smoothed_tf(term) for term in query_terms)
-```
-
-### **Data Science & Analytics**
-```python
-# Probability estimation for sparse categorical data
-category_counts = {cat: count for cat, count in data.value_counts().items()}
-estimator = freqprob.SimpleGoodTuring(category_counts)
-
-# Handle zero frequencies in statistical analysis
-smoothed_dist = freqprob.ELE(observed_frequencies, bins=total_categories)
-```
-
-## Quality & Reliability
-
-### **Rigorous Testing**
-- **200+ test cases** covering edge cases and normal operations
-- **Property-based testing** with Hypothesis for mathematical correctness
-- **Regression testing** against reference implementations (NLTK, SciPy)
-- **Numerical stability** validation for extreme inputs
-
-### **Performance Validated**
-- **Benchmarking framework** for performance regression detection
-- **Memory profiling** to ensure efficient resource usage
-- **Scaling analysis** from small to large vocabulary sizes
-- **Cross-platform testing** on Linux, Windows, and macOS
-
-### **Mathematical Accuracy**
-- **Formula verification** against academic literature
-- **Statistical correctness** validation with known distributions
-- **Precision testing** for floating-point edge cases
-- **Reference compatibility** with established libraries
-
-## Documentation & Learning
-
-Learn FreqProb through comprehensive, executable tutorials with visualizations. Tutorials are written using [Nhandu](https://pypi.org/project/nhandu) literate programming format; the rendered HTML is built from these sources (`make docs`) and published to the documentation site.
-
-1. **[Basic Smoothing Methods](docs/tutorial_1_basic_smoothing.py)**
-   - Introduction to probability smoothing
-   - MLE, Laplace, Lidstone, and ELE methods
-   - Model evaluation with perplexity
-
-2. **[Advanced Methods](docs/tutorial_2_advanced_methods.py)**
-   - Simple Good-Turing smoothing
-   - Kneser-Ney and Modified Kneser-Ney
-   - Bayesian and interpolated methods
-
-3. **[Efficiency & Memory](docs/tutorial_3_efficiency_memory.py)**
-   - Vectorized batch processing
-   - Streaming algorithms
-   - Memory-efficient representations
-
-4. **[Real-World Applications](docs/tutorial_4_real_world_applications.py)**
-   - Language modeling
-   - Text classification
-   - Information retrieval
+- **[Documentation site](https://tresoldi.github.io/freqprob/)** — user guide and
+  full API reference.
+- **[User Guide](docs/USER_GUIDE.md)** — concepts and worked examples.
+- **Tutorials** (executable, [Nhandu](https://pypi.org/project/nhandu) format):
+  [basics](docs/tutorial_1_basic_smoothing.py),
+  [advanced methods](docs/tutorial_2_advanced_methods.py),
+  [efficiency & memory](docs/tutorial_3_efficiency_memory.py),
+  [applications](docs/tutorial_4_real_world_applications.py).
 
 ## Citation
 
@@ -168,7 +94,7 @@ If you use FreqProb in academic research, please cite:
 ```bibtex
 @software{tresoldi_freqprob_2025,
   author = {Tresoldi, Tiago},
-  title = {FreqProb: A Python library for probability smoothing and frequency-based language modeling},
+  title = {FreqProb: A Python library for probability smoothing and frequency-based estimation},
   url = {https://github.com/tresoldi/freqprob},
   version = {0.4.0},
   publisher = {Department of Linguistics and Philology, Uppsala University},
@@ -176,3 +102,7 @@ If you use FreqProb in academic research, please cite:
   year = {2025}
 }
 ```
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,48 @@
+# FreqProb
+
+**Turn frequency counts into probability estimates.**
+
+FreqProb converts a mapping of elements to observed counts into smoothed
+probabilities that handle unseen elements sensibly. It is a general-purpose
+statistical tool — natural language processing is one consumer among many
+(information retrieval, ecology, genomics, categorical analytics, ML features).
+
+## Install
+
+```bash
+pip install freqprob
+```
+
+## A first example
+
+```python
+import freqprob
+
+counts = {"the": 100, "cat": 50, "dog": 30, "bird": 10}
+
+# Add-one (Laplace) smoothing over a vocabulary of 10,000 possible elements
+laplace = freqprob.Laplace(counts, bins=10_000, logprob=False)
+
+laplace("cat")       # 0.0050  — an observed element
+laplace("elephant")  # 0.0001  — an unseen element still gets non-zero mass
+```
+
+Every estimator follows the same contract: construct it with a frequency
+distribution, then call it to score an element.
+
+## Where to next
+
+- **[User Guide](USER_GUIDE.md)** — concepts, choosing a method, worked examples.
+- **[API Reference](reference.md)** — every public class and function, generated
+  from the source.
+
+## Choosing a method
+
+| Method | Good for | Key parameter |
+|--------|----------|---------------|
+| `MLE` | raw relative frequencies (no smoothing) | — |
+| `Laplace` / `Lidstone` / `ELE` | simple additive smoothing | `bins`, `gamma` |
+| `SimpleGoodTuring` | heavy-tailed count data | `p_value` |
+| `KneserNey` / `ModifiedKneserNey` | n-gram language models | `discount` |
+| `BayesianSmoothing` | Dirichlet-prior smoothing | `alpha` |
+| `InterpolatedSmoothing` | combining models of different orders | `lambda_weight` |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -1,0 +1,9 @@
+# API Reference
+
+This page is generated automatically from the docstrings in the `freqprob`
+package, so it always matches the installed code.
+
+::: freqprob
+    options:
+      show_root_heading: false
+      heading_level: 2

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,66 @@
+site_name: FreqProb
+site_description: A Python library for probability smoothing and frequency-based estimation.
+site_url: https://tresoldi.github.io/freqprob/
+repo_url: https://github.com/tresoldi/freqprob
+repo_name: tresoldi/freqprob
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - search.suggest
+    - toc.follow
+
+nav:
+  - Home: index.md
+  - User Guide: USER_GUIDE.md
+  - API Reference: reference.md
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+            show_root_heading: true
+            show_source: false
+            members_order: source
+            separate_signature: true
+            show_signature_annotations: true
+            merge_init_into_class: true
+            filters: ["!^_"]
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - toc:
+      permalink: true
+
+# Aux files kept in the repo but not part of the published site.
+exclude_docs: |
+  API_REFERENCE.md
+  LLM_DOCUMENTATION.md
+  tutorial_*.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,9 +52,14 @@ test = [
     "nltk>=3.8",
     "scikit-learn>=1.0.0",
 ]
+# Documentation site (MkDocs + mkdocstrings)
+docs = [
+    "mkdocs-material>=9.5",
+    "mkdocstrings[python]>=0.24",
+]
 # All optional dependencies (runtime + development)
 all = [
-    "freqprob[memory,dev]",
+    "freqprob[memory,dev,docs]",
 ]
 # Development dependencies
 dev = [
@@ -89,7 +94,7 @@ dev = [
 
 [project.urls]
 Homepage = "https://github.com/tresoldi/freqprob"
-Documentation = "https://github.com/tresoldi/freqprob/blob/main/docs/USER_GUIDE.md"
+Documentation = "https://tresoldi.github.io/freqprob/"
 Repository = "https://github.com/tresoldi/freqprob.git"
 Issues = "https://github.com/tresoldi/freqprob/issues"
 Changelog = "https://github.com/tresoldi/freqprob/blob/main/CHANGELOG.md"


### PR DESCRIPTION
## Summary

Phase 4 of the architectural revision (`ARCHITECTURE.md` §6): a real documentation site and a sharper README. No library code changes.

## What's included

### Documentation site (MkDocs-Material + mkdocstrings)
- `mkdocs.yml` — Material theme (light/dark), search, `mkdocstrings` Python handler pointed at `src/`.
- `docs/index.md` — concise landing page with the motivating example and a method-selection table.
- `docs/reference.md` — **API reference generated from docstrings**, replacing the hand-maintained `docs/API_REFERENCE.md` that would drift from the code. (The old file and `LLM_DOCUMENTATION.md` stay in the repo but are excluded from the site.)
- New **`docs` extra** (`mkdocs-material`, `mkdocstrings[python]`); `make site` builds it (`--strict`), `make site-serve` previews it.
- Verified locally: `mkdocs build --strict` passes, and the generated reference includes the public classes.

### README rewrite
- Leads with the core value (**counts → probabilities**) and one motivating example (the unseen-`elephant` case — verified against the implementation).
- Adds a **method-selection table**.
- Frames FreqProb as **general-purpose**, not NLP-only.
- Collapses the three repeated "testing" sections into one; ~180 → ~110 lines.
- Documentation links point at the site.

## ⚠️ Two manual steps to publish the site (I can't push workflow files)

**1. Add this workflow** as `.github/workflows/docs.yml`:

```yaml
name: Docs

on:
  push:
    branches: [main]
  workflow_dispatch:

permissions:
  contents: read
  pages: write
  id-token: write

concurrency:
  group: pages
  cancel-in-progress: false

jobs:
  build:
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v4
      - uses: actions/setup-python@v5
        with:
          python-version: '3.12'
      - run: |
          python -m pip install --upgrade pip
          pip install -e ".[docs]"
      - run: mkdocs build --strict
      - uses: actions/upload-pages-artifact@v3
        with:
          path: site

  deploy:
    needs: build
    runs-on: ubuntu-latest
    environment:
      name: github-pages
      url: ${{ steps.deployment.outputs.page_url }}
    steps:
      - id: deployment
        uses: actions/deploy-pages@v4
```

**2. Enable Pages**: repo **Settings → Pages → Build and deployment → Source: GitHub Actions**.

Once both are done, the site publishes to `https://tresoldi.github.io/freqprob/` on every push to `main` (that URL is already wired into the README badge and the `Documentation` project URL — it will 404 until the first deploy).

## Depends on

Builds on Phases 1–3 (merged). This is the last additive phase; the remaining Phase 5 (naming/terminology → clean-break 1.0.0) changes the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_