### PR TITLE
feat!: public-API pass and serialization → 0.6.0 (Phase 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-07-24
+
+### Changed - BREAKING
+
+- **Renamed estimator classes** (dropped the inconsistent `Smoothing` suffix):
+  `BayesianSmoothing` → `Bayesian`, `InterpolatedSmoothing` → `Interpolated`.
+  Constructor parameters and behavior are unchanged. Additionally, direct imports of
+  the old internal module paths changed during the internal reorganization; import
+  from the top-level `freqprob` namespace instead. Full details in `MIGRATION.md`.
+
 ### Added
 
+- **scikit-learn-style API**: `fit()` / `predict()` / `score()` methods on every
+  estimator, alongside the existing callable contract. `score` is a single-element
+  alias for `__call__`; `predict` scores an iterable in one call.
+- **Model serialization**: `save(path)` / `load(path)` on `ScoringMethod` to persist
+  and restore a fitted estimator without re-fitting (pickle-based). `load()` validates
+  the object type and documents the trust requirement of unpickling.
+- **Public `ScoringMethod` base type**: exported from `freqprob` for `isinstance`
+  checks and type annotations.
 - **Documentation site** (MkDocs-Material + mkdocstrings): `mkdocs.yml`, a landing
   page, and an API reference generated from docstrings (so it can't drift from the
   code). Build with `make site` / preview with `make site-serve`; a new `docs` extra

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,7 @@ authors:
     given-names: Tiago
     affiliation: "Department of Linguistics and Philology, Uppsala University"
     email: tiago.tresoldi@lingfil.uu.se
-version: 0.4.0
+version: 0.6.0
 license: MIT
 repository-code: "https://github.com/tresoldi/freqprob"
 url: "https://github.com/tresoldi/freqprob"

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,68 @@
+# Migration Guide
+
+## Migrating to 0.6.0
+
+Version 0.6.0 completes a multi-phase internal restructuring and introduces a
+small, deliberate set of public-API changes. The **top-level `freqprob`
+namespace is the stable, supported surface** — if you import everything from
+`freqprob` directly, the only change you need is the two class renames below.
+
+### Breaking changes
+
+#### 1. Renamed estimator classes
+
+The inconsistent `Smoothing` suffix was dropped so all estimator names are
+uniform:
+
+| Old name | New name |
+|----------|----------|
+| `BayesianSmoothing` | `Bayesian` |
+| `InterpolatedSmoothing` | `Interpolated` |
+
+```python
+# Before
+from freqprob import BayesianSmoothing, InterpolatedSmoothing
+model = BayesianSmoothing(counts, alpha=1.0)
+
+# After
+from freqprob import Bayesian, Interpolated
+model = Bayesian(counts, alpha=1.0)
+```
+
+Constructor parameters and behavior are unchanged.
+
+#### 2. Internal module paths moved
+
+If you imported from **internal module paths** rather than the top-level
+namespace, those paths changed when the package was reorganized:
+
+| Old import | New location |
+|------------|--------------|
+| `from freqprob.basic import MLE, Uniform, Random` | `from freqprob import ...` (or `freqprob.methods.baselines`) |
+| `from freqprob.lidstone import Laplace, Lidstone, ELE` | `from freqprob import ...` (or `freqprob.methods.additive`) |
+| `from freqprob.advanced import SimpleGoodTuring, WittenBell` | `from freqprob import ...` (or `freqprob.methods.goodturing`) |
+| `from freqprob.smoothing import KneserNey, ...` | `from freqprob import ...` (or `freqprob.methods.kneser_ney` / `interpolated` / `bayesian`) |
+| `from freqprob.utils import perplexity, ...` | `from freqprob import ...` (or `freqprob.metrics`) |
+| `from freqprob.utils import generate_ngrams, ...` | `from freqprob import ...` (or `freqprob.text`) |
+| `from freqprob.lazy / vectorized / streaming / memory_efficient / profiling import ...` | `from freqprob import ...` (or `freqprob.performance.*`) |
+
+**Recommended:** import from the top-level `freqprob` namespace, which is
+stable across these moves.
+
+### New features (non-breaking)
+
+- **scikit-learn-style aliases** on every estimator, alongside the existing
+  callable contract:
+  ```python
+  scorer.fit(freqdist)        # returns self
+  scorer.score(element)       # single element (alias for scorer(element))
+  scorer.predict(elements)    # batch: list of scores
+  ```
+- **Serialization** — persist and restore a fitted estimator without re-fitting:
+  ```python
+  scorer.save("model.pkl")
+  restored = freqprob.KneserNey.load("model.pkl")
+  ```
+  `load()` only accepts files you trust (unpickling executes code).
+- **`freqprob.ScoringMethod`** — the estimator base type is now public, for
+  `isinstance` checks and type annotations.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ freqprob.perplexity(scorer, test_bigrams)
 | `Laplace` / `Lidstone` / `ELE` | simple, robust additive smoothing | `bins`, `gamma` |
 | `SimpleGoodTuring` | heavy-tailed count data (many rare items) | `p_value` |
 | `KneserNey` / `ModifiedKneserNey` | n-gram language models | `discount` |
-| `BayesianSmoothing` | Dirichlet-prior smoothing | `alpha` |
-| `InterpolatedSmoothing` | combining models of different orders | `lambda_weight` |
+| `Bayesian` | Dirichlet-prior smoothing | `alpha` |
+| `Interpolated` | combining models of different orders | `lambda_weight` |
 | `WittenBell`, `CertaintyDegree`, `Uniform`, `Random` | baselines & specialized cases | — |
 
 For large or streaming data, FreqProb also provides vectorized batch scoring,

--- a/README.md
+++ b/README.md
@@ -44,11 +44,17 @@ distribution, then **call it** to score an element.
 
 ```python
 scorer = freqprob.KneserNey(bigram_counts, discount=0.75)
-scorer(("the", "cat"))          # log-probability of a bigram
+scorer(("the", "cat"))                              # score one element
+scorer.predict([("the", "cat"), ("a", "dog")])      # score many (scikit-learn-style)
 
-# Evaluate a model
-freqprob.perplexity(scorer, test_bigrams)
+freqprob.perplexity(scorer, test_bigrams)           # evaluate a model
+
+scorer.save("model.pkl")                            # persist a fitted model...
+scorer = freqprob.KneserNey.load("model.pkl")       # ...and load it back
 ```
+
+`fit`/`predict`/`score` aliases are available for scikit-learn familiarity, and
+any fitted estimator can be saved and reloaded without re-fitting.
 
 ## Choosing a method
 
@@ -96,7 +102,7 @@ If you use FreqProb in academic research, please cite:
   author = {Tresoldi, Tiago},
   title = {FreqProb: A Python library for probability smoothing and frequency-based estimation},
   url = {https://github.com/tresoldi/freqprob},
-  version = {0.4.0},
+  version = {0.6.0},
   publisher = {Department of Linguistics and Philology, Uppsala University},
   address = {Uppsala},
   year = {2025}

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -383,17 +383,17 @@ print(mkn(('the', 'cat')))
 
 ---
 
-### InterpolatedSmoothing
+### Interpolated
 
 Linear interpolation between two models with automatic n-gram mode detection.
 
 ```python
-class InterpolatedSmoothing(ScoringMethod)
+class Interpolated(ScoringMethod)
 ```
 
 **Constructor:**
 ```python
-InterpolatedSmoothing(high_order_dist: FrequencyDistribution,
+Interpolated(high_order_dist: FrequencyDistribution,
                       low_order_dist: FrequencyDistribution,
                       lambda_weight: float = 0.7,
                       logprob: bool = True)
@@ -425,7 +425,7 @@ N-gram interpolation (trigrams + bigrams):
 ```python
 trigrams = {('the', 'big', 'cat'): 3, ('a', 'big', 'dog'): 2}
 bigrams = {('big', 'cat'): 5, ('big', 'dog'): 3, ('small', 'cat'): 2}
-interp = freqprob.InterpolatedSmoothing(trigrams, bigrams, lambda_weight=0.7, logprob=False)
+interp = freqprob.Interpolated(trigrams, bigrams, lambda_weight=0.7, logprob=False)
 print(interp(('the', 'big', 'cat')))  # 0.57 = 0.7 * (3/5) + 0.3 * (5/10)
 print(interp(('unseen', 'big', 'cat')))  # 0.15 = 0.7 * 0 + 0.3 * (5/10)
 ```
@@ -434,7 +434,7 @@ Same-type interpolation (strings):
 ```python
 high_freq = {'cat': 10, 'dog': 5}
 low_freq = {'cat': 3, 'dog': 2, 'bird': 1}
-interp = freqprob.InterpolatedSmoothing(high_freq, low_freq, lambda_weight=0.8, logprob=False)
+interp = freqprob.Interpolated(high_freq, low_freq, lambda_weight=0.8, logprob=False)
 ```
 
 **Mathematical Formulas:**
@@ -452,17 +452,17 @@ $$P_{interp}(w) = \lambda P_{high}(w) + (1-\lambda) P_{low}(w)$$
 
 ---
 
-### BayesianSmoothing
+### Bayesian
 
 Bayesian smoothing with Dirichlet prior.
 
 ```python
-class BayesianSmoothing(ScoringMethod)
+class Bayesian(ScoringMethod)
 ```
 
 **Constructor:**
 ```python
-BayesianSmoothing(freqdist: FrequencyDistribution,
+Bayesian(freqdist: FrequencyDistribution,
                   alpha: float = 1.0,
                   logprob: bool = True)
 ```
@@ -475,7 +475,7 @@ BayesianSmoothing(freqdist: FrequencyDistribution,
 **Example:**
 ```python
 freqdist = {'cat': 3, 'dog': 2, 'bird': 1}
-bayesian = freqprob.BayesianSmoothing(freqdist, alpha=0.5, logprob=False)
+bayesian = freqprob.Bayesian(freqdist, alpha=0.5, logprob=False)
 print(bayesian('cat'))
 ```
 

--- a/docs/LLM_DOCUMENTATION.md
+++ b/docs/LLM_DOCUMENTATION.md
@@ -218,10 +218,10 @@ lidstone = freqprob.Lidstone(counts, gamma=0.5, bins=5000, logprob=True)
 counts = {"positive": 20, "negative": 5, "neutral": 2}
 
 # Weak prior (α = 0.5)
-weak_prior = freqprob.BayesianSmoothing(counts, alpha=0.5, logprob=False)
+weak_prior = freqprob.Bayesian(counts, alpha=0.5, logprob=False)
 
 # Strong prior (α = 10.0) - assumes uniform distribution
-strong_prior = freqprob.BayesianSmoothing(counts, alpha=10.0, logprob=False)
+strong_prior = freqprob.Bayesian(counts, alpha=10.0, logprob=False)
 
 # Strong prior pulls probabilities toward uniform
 print(weak_prior("positive"))    # Closer to MLE
@@ -318,7 +318,7 @@ mle_model = freqprob.MLE(counts, logprob=True)
 laplace_model = freqprob.Laplace(counts, bins=5000, logprob=True)
 
 # Interpolate with custom weights
-interpolated = freqprob.InterpolatedSmoothing(
+interpolated = freqprob.Interpolated(
     [mle_model, laplace_model],
     weights=[0.7, 0.3],  # 70% MLE, 30% Laplace
     logprob=True
@@ -625,7 +625,7 @@ models = {
     "mle": freqprob.MLE(train_counts, logprob=True),
     "laplace": freqprob.Laplace(train_counts, bins=1000, logprob=True),
     "ele": freqprob.ELE(train_counts, bins=1000, logprob=True),
-    "bayesian": freqprob.BayesianSmoothing(train_counts, alpha=1.0, logprob=True),
+    "bayesian": freqprob.Bayesian(train_counts, alpha=1.0, logprob=True),
 }
 
 comparison = freqprob.model_comparison(models, test_data)
@@ -782,8 +782,8 @@ def select_best_model(train_data, validation_data, vocab_size):
     models = {
         "laplace": freqprob.Laplace(train_counts, bins=vocab_size, logprob=True),
         "ele": freqprob.ELE(train_counts, bins=vocab_size, logprob=True),
-        "bayesian_0.5": freqprob.BayesianSmoothing(train_counts, alpha=0.5, logprob=True),
-        "bayesian_1.0": freqprob.BayesianSmoothing(train_counts, alpha=1.0, logprob=True),
+        "bayesian_0.5": freqprob.Bayesian(train_counts, alpha=0.5, logprob=True),
+        "bayesian_1.0": freqprob.Bayesian(train_counts, alpha=1.0, logprob=True),
     }
 
     # Evaluate on validation set
@@ -846,7 +846,7 @@ def adapt_model(general_counts, domain_counts, domain_weight=0.7):
     domain_model = freqprob.ELE(domain_counts, bins=5000, logprob=True)
 
     # Interpolate with domain preference
-    adapted = freqprob.InterpolatedSmoothing(
+    adapted = freqprob.Interpolated(
         [domain_model, general_model],
         weights=[domain_weight, 1 - domain_weight],
         logprob=True
@@ -1044,10 +1044,10 @@ log_sum = logsumexp(log_probs)
 # Main classes
 from freqprob import (
     MLE, Laplace, Lidstone, ELE,
-    BayesianSmoothing, SimpleGoodTuring,
+    Bayesian, SimpleGoodTuring,
     KneserNey, ModifiedKneserNey,
     WittenBell, CertaintyDegree,
-    InterpolatedSmoothing,
+    Interpolated,
 )
 
 # Utilities
@@ -1142,7 +1142,7 @@ class TextCategorizer:
                     counts, bins=self.vocab_size, logprob=True
                 )
             elif self.smoothing == "bayesian":
-                model = freqprob.BayesianSmoothing(
+                model = freqprob.Bayesian(
                     counts, alpha=1.0, logprob=True
                 )
             else:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -356,7 +356,7 @@ $$P_{interp}(w) = \lambda P_{high}(w) + (1-\lambda) P_{low}(w)$$
 trigrams = {('the', 'big', 'cat'): 3, ('a', 'big', 'dog'): 2}
 bigrams = {('big', 'cat'): 5, ('big', 'dog'): 3, ('small', 'cat'): 2}
 
-interpolated = freqprob.InterpolatedSmoothing(
+interpolated = freqprob.Interpolated(
     trigrams, bigrams, lambda_weight=0.7, logprob=False
 )
 
@@ -369,7 +369,7 @@ print(interpolated(('unseen', 'big', 'cat')))
 # Same-type interpolation (strings)
 high_freq = {'cat': 10, 'dog': 5}
 low_freq = {'cat': 3, 'dog': 2, 'bird': 1}
-interp_str = freqprob.InterpolatedSmoothing(
+interp_str = freqprob.Interpolated(
     high_freq, low_freq, lambda_weight=0.8, logprob=False
 )
 ```
@@ -395,7 +395,7 @@ where $\alpha$ is the Dirichlet concentration parameter.
 
 **Implementation:**
 ```python
-bayesian = freqprob.BayesianSmoothing(freqdist, alpha=1.0, logprob=False)
+bayesian = freqprob.Bayesian(freqdist, alpha=1.0, logprob=False)
 ```
 
 ## Computational Efficiency
@@ -855,7 +855,7 @@ print(f"Feature vectors: {len(features)} x {len(features[0])}")
 ```python
 def build_document_language_model(document, background_model, lambda_mix=0.8):
     """Build a smoothed document language model."""
-    from freqprob import word_frequency, InterpolatedSmoothing
+    from freqprob import word_frequency, Interpolated
 
     # Document term frequencies
     doc_freqdist = word_frequency(document.split())
@@ -864,7 +864,7 @@ def build_document_language_model(document, background_model, lambda_mix=0.8):
     doc_model = freqprob.MLE(doc_freqdist, logprob=True)
 
     # Interpolate with background model
-    interpolated = InterpolatedSmoothing(
+    interpolated = Interpolated(
         doc_freqdist, background_model._freqdist,
         lambda_weight=lambda_mix, logprob=True
     )

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,5 +44,5 @@ distribution, then call it to score an element.
 | `Laplace` / `Lidstone` / `ELE` | simple additive smoothing | `bins`, `gamma` |
 | `SimpleGoodTuring` | heavy-tailed count data | `p_value` |
 | `KneserNey` / `ModifiedKneserNey` | n-gram language models | `discount` |
-| `BayesianSmoothing` | Dirichlet-prior smoothing | `alpha` |
-| `InterpolatedSmoothing` | combining models of different orders | `lambda_weight` |
+| `Bayesian` | Dirichlet-prior smoothing | `alpha` |
+| `Interpolated` | combining models of different orders | `lambda_weight` |

--- a/docs/tutorial_2_advanced_methods.py
+++ b/docs/tutorial_2_advanced_methods.py
@@ -425,7 +425,7 @@ try:
     # Lambda weight controls interpolation: λ * P_high + (1-λ) * P_low
     lambda_weight = 0.7  # Favor trigrams
 
-    interpolated = freqprob.InterpolatedSmoothing(
+    interpolated = freqprob.Interpolated(
         trigram_freqdist, bigram_freqdist, lambda_weight=lambda_weight, logprob=False
     )
 
@@ -457,7 +457,7 @@ try:
 
     probs_by_lambda = []
     for lam in lambda_values:
-        interp_model = freqprob.InterpolatedSmoothing(
+        interp_model = freqprob.Interpolated(
             trigram_freqdist, bigram_freqdist, lambda_weight=lam, logprob=False
         )
         prob = interp_model(test_trigram)
@@ -495,7 +495,7 @@ alpha_values = [0.1, 0.5, 1.0, 2.0, 5.0]
 bayesian_models = {}
 
 for alpha in alpha_values:
-    bayesian_models[alpha] = freqprob.BayesianSmoothing(freqdist, alpha=alpha, logprob=False)
+    bayesian_models[alpha] = freqprob.Bayesian(freqdist, alpha=alpha, logprob=False)
 
 print("Bayesian Smoothing with different alpha (concentration parameters):")
 print("=" * 65)
@@ -593,7 +593,7 @@ print("=" * 40)
 unigram_models = {
     "MLE": freqprob.MLE(freqdist, logprob=True),
     "Laplace": freqprob.Laplace(freqdist, bins=1000, logprob=True),
-    "Bayesian (alpha=0.5)": freqprob.BayesianSmoothing(freqdist, alpha=0.5, logprob=True),
+    "Bayesian (alpha=0.5)": freqprob.Bayesian(freqdist, alpha=0.5, logprob=True),
 }
 
 if sgt is not None:

--- a/docs/tutorial_4_real_world_applications.py
+++ b/docs/tutorial_4_real_world_applications.py
@@ -434,7 +434,7 @@ class ProbabilisticTextClassifier:
                     frequencies, bins=vocab_size, logprob=True
                 )
             elif self.smoothing_method == "bayesian":
-                self.class_models[class_label] = freqprob.BayesianSmoothing(
+                self.class_models[class_label] = freqprob.Bayesian(
                     frequencies, alpha=0.5, logprob=True
                 )
             else:  # MLE
@@ -1097,7 +1097,7 @@ class SentimentAnalyzer:
 
         for sentiment, frequencies in sentiment_frequencies.items():
             if self.smoothing == "bayesian":
-                self.sentiment_models[sentiment] = freqprob.BayesianSmoothing(
+                self.sentiment_models[sentiment] = freqprob.Bayesian(
                     frequencies, alpha=0.5, logprob=True
                 )
             elif self.smoothing == "laplace":

--- a/scripts/benchmarks.py
+++ b/scripts/benchmarks.py
@@ -6,7 +6,7 @@ smoothing methods across different scenarios and datasets.
 
 Benchmarks v0.4.0 features:
 - SimpleGoodTuring with bins parameter (per-word probability)
-- InterpolatedSmoothing with n-gram mode (trigram + bigram)
+- Interpolated with n-gram mode (trigram + bigram)
 - KneserNey and ModifiedKneserNey methods
 - Cross-entropy evaluation
 - N-gram datasets (bigrams, trigrams)
@@ -235,8 +235,8 @@ class PerformanceBenchmark:
             "Lidstone_0.5": lambda freq: freqprob.Lidstone(
                 freq, gamma=0.5, bins=len(freq) * 2, logprob=True
             ),
-            "Bayesian_0.5": lambda freq: freqprob.BayesianSmoothing(freq, alpha=0.5, logprob=True),
-            "Bayesian_1.0": lambda freq: freqprob.BayesianSmoothing(freq, alpha=1.0, logprob=True),
+            "Bayesian_0.5": lambda freq: freqprob.Bayesian(freq, alpha=0.5, logprob=True),
+            "Bayesian_1.0": lambda freq: freqprob.Bayesian(freq, alpha=1.0, logprob=True),
         }
 
         # Add SimpleGoodTuring with different bins configurations (v0.4.0)
@@ -302,7 +302,7 @@ class PerformanceBenchmark:
                 sparse_data[f"word_{i:06d}"] = max(1, int(np.random.exponential(2)))
         self.datasets["sparse"] = sparse_data
 
-        # N-gram datasets (for KneserNey, ModifiedKneserNey, InterpolatedSmoothing)
+        # N-gram datasets (for KneserNey, ModifiedKneserNey, Interpolated)
         self.datasets["bigram_small"] = DatasetGenerator.create_bigram_distribution(50, 500)
         self.datasets["bigram_medium"] = DatasetGenerator.create_bigram_distribution(100, 2000)
         self.datasets["trigram_small"] = DatasetGenerator.create_trigram_distribution(30, 300)
@@ -508,7 +508,7 @@ class PerformanceBenchmark:
                     pass
 
     def benchmark_ngram_methods(self) -> None:
-        """Benchmark n-gram specific methods (KneserNey, ModifiedKneserNey, InterpolatedSmoothing)."""
+        """Benchmark n-gram specific methods (KneserNey, ModifiedKneserNey, Interpolated)."""
         print("Benchmarking n-gram methods...")
 
         # Benchmark KneserNey and ModifiedKneserNey on bigram datasets
@@ -555,8 +555,8 @@ class PerformanceBenchmark:
                     )
                     self.results.append(result)
 
-        # Benchmark InterpolatedSmoothing (trigram + bigram)
-        print("  Benchmarking InterpolatedSmoothing...")
+        # Benchmark Interpolated (trigram + bigram)
+        print("  Benchmarking Interpolated...")
         for lambda_weight in [0.5, 0.7, 0.9]:
             # Find matching trigram and bigram datasets
             if "trigram_small" in self.datasets and "bigram_small" in self.datasets:
@@ -567,13 +567,13 @@ class PerformanceBenchmark:
                 for _ in range(3):
                     start_time = time.perf_counter()
                     try:
-                        model = freqprob.InterpolatedSmoothing(
+                        model = freqprob.Interpolated(
                             trigram_data, bigram_data, lambda_weight=lambda_weight, logprob=True
                         )
                         end_time = time.perf_counter()
                         times.append(end_time - start_time)
                     except Exception as e:
-                        print(f"    Warning: InterpolatedSmoothing λ={lambda_weight} failed: {e}")
+                        print(f"    Warning: Interpolated λ={lambda_weight} failed: {e}")
                         times.append(float("inf"))
 
                 valid_times = [t for t in times if t != float("inf")]

--- a/src/freqprob/__init__.py
+++ b/src/freqprob/__init__.py
@@ -1,7 +1,7 @@
 """FreqProb: frequency-based probability estimation library."""
 
 # Version of the freqprob package
-__version__ = "0.4.0"
+__version__ = "0.6.0"
 __author__ = "Tiago Tresoldi"
 __email__ = "tiago.tresoldi@lingfil.uu.se"
 

--- a/src/freqprob/__init__.py
+++ b/src/freqprob/__init__.py
@@ -6,6 +6,9 @@ __author__ = "Tiago Tresoldi"
 __email__ = "tiago.tresoldi@lingfil.uu.se"
 
 
+# Base type (useful for isinstance checks and type annotations)
+from .base import ScoringMethod
+
 # Core estimators, grouped by family under methods/
 from .cache import clear_all_caches, get_cache_stats
 from .methods.additive import ELE, Laplace, Lidstone
@@ -63,6 +66,7 @@ __all__ = [
     "ModifiedKneserNey",
     "QuantizedProbabilityTable",
     "Random",
+    "ScoringMethod",
     "SimpleGoodTuring",
     "SparseFrequencyDistribution",
     "StreamingDataProcessor",

--- a/src/freqprob/__init__.py
+++ b/src/freqprob/__init__.py
@@ -10,10 +10,10 @@ __email__ = "tiago.tresoldi@lingfil.uu.se"
 from .cache import clear_all_caches, get_cache_stats
 from .methods.additive import ELE, Laplace, Lidstone
 from .methods.baselines import MLE, Random, Uniform
-from .methods.bayesian import BayesianSmoothing
+from .methods.bayesian import Bayesian
 from .methods.certainty import CertaintyDegree
 from .methods.goodturing import SimpleGoodTuring, WittenBell
-from .methods.interpolated import InterpolatedSmoothing
+from .methods.interpolated import Interpolated
 from .methods.kneser_ney import KneserNey, ModifiedKneserNey
 
 # Model-evaluation metrics and (NLP) text helpers
@@ -48,11 +48,11 @@ __all__ = [
     "ELE",
     "MLE",
     "BatchScorer",
-    "BayesianSmoothing",
+    "Bayesian",
     "CertaintyDegree",
     "CompressedFrequencyDistribution",
     "DistributionMemoryAnalyzer",
-    "InterpolatedSmoothing",
+    "Interpolated",
     "KneserNey",
     "Laplace",
     "LazyBatchScorer",

--- a/src/freqprob/base.py
+++ b/src/freqprob/base.py
@@ -5,7 +5,7 @@ for all smoothing methods in the freqprob library.
 """
 
 from abc import ABC, abstractmethod
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any, TypeVar
 
@@ -243,3 +243,45 @@ class ScoringMethod(ABC):
         self._compute_probabilities(freqdist)
 
         return self
+
+    def score(self, element: Element) -> Probability | LogProbability:
+        """Score a single element (scikit-learn-style alias for ``__call__``).
+
+        Parameters
+        ----------
+        element : Element
+            Element to be scored
+
+        Returns:
+        -------
+        Probability | LogProbability
+            The probability (or log-probability) of the element
+
+        Examples:
+        --------
+        >>> scorer = MLE({'a': 2, 'b': 1}, logprob=False)
+        >>> scorer.score('a')
+        0.6666666666666666
+        """
+        return self(element)
+
+    def predict(self, elements: Iterable[Element]) -> list[Probability | LogProbability]:
+        """Score many elements at once (scikit-learn-style batch alias).
+
+        Parameters
+        ----------
+        elements : Iterable[Element]
+            Elements to be scored
+
+        Returns:
+        -------
+        list[Probability | LogProbability]
+            One probability (or log-probability) per input element, in order
+
+        Examples:
+        --------
+        >>> scorer = MLE({'a': 2, 'b': 1}, logprob=False)
+        >>> scorer.predict(['a', 'b', 'c'])
+        [0.6666666666666666, 0.3333333333333333, 0.0]
+        """
+        return [self(element) for element in elements]

--- a/src/freqprob/base.py
+++ b/src/freqprob/base.py
@@ -4,10 +4,14 @@ This module provides the abstract base class and common functionality
 for all smoothing methods in the freqprob library.
 """
 
+import pickle
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, TypeVar
+
+from typing_extensions import Self
 
 # Type aliases for clarity
 Element = str | int | float | tuple[Any, ...] | frozenset[Any]
@@ -285,3 +289,69 @@ class ScoringMethod(ABC):
         [0.6666666666666666, 0.3333333333333333, 0.0]
         """
         return [self(element) for element in elements]
+
+    def __getstate__(self) -> dict[str, Any]:
+        """Collect all ``__slots__`` values across the class hierarchy for pickling."""
+        state: dict[str, Any] = {}
+        for klass in type(self).__mro__:
+            for slot in getattr(klass, "__slots__", ()):
+                if hasattr(self, slot):
+                    state[slot] = getattr(self, slot)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        """Restore ``__slots__`` values from a pickled state."""
+        for slot, value in state.items():
+            setattr(self, slot, value)
+
+    def save(self, path: str | Path) -> None:
+        """Serialize this fitted scorer to a file.
+
+        The scorer can be restored later with :meth:`load`, avoiding the cost of
+        re-fitting. Serialization uses :mod:`pickle`.
+
+        Parameters
+        ----------
+        path : str | Path
+            Destination file path
+
+        Examples:
+        --------
+        >>> scorer = MLE({'a': 2, 'b': 1}, logprob=False)
+        >>> scorer.save('model.pkl')                 # doctest: +SKIP
+        >>> restored = MLE.load('model.pkl')         # doctest: +SKIP
+        >>> restored('a') == scorer('a')             # doctest: +SKIP
+        True
+        """
+        with Path(path).open("wb") as fh:
+            pickle.dump(self, fh, protocol=pickle.HIGHEST_PROTOCOL)
+
+    @classmethod
+    def load(cls, path: str | Path) -> Self:
+        """Load a scorer previously written with :meth:`save`.
+
+        Parameters
+        ----------
+        path : str | Path
+            Path to a file created by :meth:`save`
+
+        Returns:
+        -------
+        ScoringMethod
+            The restored scorer
+
+        Raises:
+        ------
+        TypeError
+            If the file does not contain a compatible scorer
+
+        Warning:
+        -------
+        Only load files you trust: unpickling executes arbitrary code from the
+        file, so never load a scorer from an untrusted source.
+        """
+        with Path(path).open("rb") as fh:
+            obj = pickle.load(fh)
+        if not isinstance(obj, cls):
+            raise TypeError(f"File does not contain a {cls.__name__}: got {type(obj).__name__}")
+        return obj

--- a/src/freqprob/methods/additive.py
+++ b/src/freqprob/methods/additive.py
@@ -39,7 +39,7 @@ class Lidstone(ScoringMethod):
         - gamma = 0.5: Jeffreys prior (Expected Likelihood Estimation)
         - gamma → 0: Approaches MLE
     bins : int | None, default=None
-        Total number of possible elements. If None, uses vocabulary size |V|
+        Total number of possible elements. If None, uses support size |V|
     logprob : bool, default=True
         Whether to return log-probabilities or probabilities
 
@@ -89,7 +89,7 @@ class Lidstone(ScoringMethod):
     - Small gamma: Low bias but high variance (closer to MLE)
     - Large gamma: Higher bias but lower variance (more uniform)
 
-    When bins > vocabulary size, the method reserves more probability
+    When bins > support size, the method reserves more probability
     mass for potential unseen elements.
     """
 
@@ -103,7 +103,7 @@ class Lidstone(ScoringMethod):
         logprob: bool = True,
     ) -> None:
         """Initialize Lidstone smoothing."""
-        # Default bins to vocabulary size if not specified
+        # Default bins to support size if not specified
         if bins is None:
             bins = len(freqdist)
 
@@ -162,7 +162,7 @@ class Laplace(Lidstone):
     freqdist : FrequencyDistribution
         Frequency distribution mapping elements to their observed counts
     bins : int | None, default=None
-        Total number of possible elements. If None, uses vocabulary size |V|
+        Total number of possible elements. If None, uses support size |V|
     logprob : bool, default=True
         Whether to return log-probabilities or probabilities
 
@@ -219,7 +219,7 @@ class ELE(Lidstone):
     freqdist : FrequencyDistribution
         Frequency distribution mapping elements to their observed counts
     bins : int | None, default=None
-        Total number of possible elements. If None, uses vocabulary size |V|
+        Total number of possible elements. If None, uses support size |V|
     logprob : bool, default=True
         Whether to return log-probabilities or probabilities
 

--- a/src/freqprob/methods/baselines.py
+++ b/src/freqprob/methods/baselines.py
@@ -49,7 +49,7 @@ class Uniform(ScoringMethod):
     ----------
     freqdist : FrequencyDistribution
         Frequency distribution mapping elements to their observed counts.
-        Note: counts are ignored, only vocabulary size matters.
+        Note: counts are ignored, only support size matters.
     unobs_prob : Probability, default=0.0
         Reserved probability mass for unobserved elements (0.0 ≤ p₀ ≤ 1.0)
     logprob : bool, default=True
@@ -100,7 +100,7 @@ class Uniform(ScoringMethod):
         Parameters
         ----------
         freqdist : FrequencyDistribution
-            Frequency distribution (counts are ignored, only vocabulary size used)
+            Frequency distribution (counts are ignored, only support size used)
         """
         unobs_prob = self.config.unobs_prob or 0.0
 

--- a/src/freqprob/methods/bayesian.py
+++ b/src/freqprob/methods/bayesian.py
@@ -40,7 +40,7 @@ class Bayesian(ScoringMethod):
     - cᵢ is the observed count for word wᵢ
     - alpha is the Dirichlet concentration parameter (pseudocount)
     - N is the total observed count
-    - V is the vocabulary size
+    - V is the support size
 
     This is equivalent to adding alpha pseudocounts to each possible outcome
     and corresponds to the posterior mean under a symmetric Dirichlet prior.

--- a/src/freqprob/methods/bayesian.py
+++ b/src/freqprob/methods/bayesian.py
@@ -25,7 +25,7 @@ class BayesianConfig(ScoringMethodConfig):
     alpha: float = 1.0
 
 
-class BayesianSmoothing(ScoringMethod):
+class Bayesian(ScoringMethod):
     """Bayesian smoothing with Dirichlet prior.
 
     Uses a Dirichlet prior distribution to provide Bayesian probability estimates.
@@ -61,7 +61,7 @@ class BayesianSmoothing(ScoringMethod):
     --------
     Basic Bayesian smoothing with uniform prior:
     >>> freqdist = {'apple': 8, 'banana': 4, 'cherry': 1}
-    >>> bayes = BayesianSmoothing(freqdist, alpha=1.0, logprob=False)
+    >>> bayes = Bayesian(freqdist, alpha=1.0, logprob=False)
     >>> bayes('apple')     # (8+1)/(13+3*1) = 9/16
     0.5625
     >>> bayes('banana')    # (4+1)/(13+3*1) = 5/16
@@ -71,14 +71,14 @@ class BayesianSmoothing(ScoringMethod):
 
     Effect of different alpha values:
     >>> # Stronger smoothing (alpha = 2)
-    >>> bayes_smooth = BayesianSmoothing(freqdist, alpha=2.0, logprob=False)
+    >>> bayes_smooth = Bayesian(freqdist, alpha=2.0, logprob=False)
     >>> bayes_smooth('apple')    # (8+2)/(13+3*2) = 10/19
     0.5263157894736842
     >>> bayes_smooth('unseen')   # 2/(13+3*2) = 2/19
     0.10526315789473684
 
     >>> # Minimal smoothing (alpha = 0.1)
-    >>> bayes_minimal = BayesianSmoothing(freqdist, alpha=0.1, logprob=False)
+    >>> bayes_minimal = Bayesian(freqdist, alpha=0.1, logprob=False)
     >>> bayes_minimal('apple')   # (8+0.1)/(13+3*0.1) ≈ 8.1/13.3
     0.6090226699248121
 

--- a/src/freqprob/methods/goodturing.py
+++ b/src/freqprob/methods/goodturing.py
@@ -91,7 +91,7 @@ class SimpleGoodTuringConfig(ScoringMethodConfig):
     default_p0 : float | None
         Fallback probability for unobserved elements (default: None)
     bins : int | None
-        Total vocabulary size for per-word probability calculation (default: None).
+        Total support size for per-word probability calculation (default: None).
         If None, uses heuristic: bins = V_observed + N1 (singletons).
         This determines how p0 (total unseen mass) is distributed across unseen words.
     logprob : bool
@@ -150,10 +150,10 @@ class SimpleGoodTuring(ScoringMethod):
         for the current frequency distribution. Please note that this is
         intended change from the reference implementation by Gale and Sampson.
     bins : int | None
-        Total vocabulary size for calculating per-word unseen probabilities.
+        Total support size for calculating per-word unseen probabilities.
         If None (default), uses heuristic: bins = V_observed + N1, where N1 is
         the number of singleton words. This assumes approximately as many unseen
-        types as singletons. Users can specify exact vocabulary size if known.
+        types as singletons. Users can specify exact support size if known.
     logprob : bool
         Whether to return the log-probabilities (default) or the
         probabilities themselves. When using the log-probabilities, the
@@ -342,7 +342,8 @@ class SimpleGoodTuring(ScoringMethod):
         # Validate bins value
         if bins <= len(freqdist):
             raise ValueError(
-                f"bins ({bins}) must be greater than observed vocabulary size ({len(freqdist)}). "
+                f"bins ({bins}) must be greater than the number of observed elements "
+                f"({len(freqdist)}). "
                 f"Consider bins = {len(freqdist) + max(freqs_of_freqs.get(1, 0), 1)} (V + N1 heuristic)"
             )
 

--- a/src/freqprob/methods/interpolated.py
+++ b/src/freqprob/methods/interpolated.py
@@ -28,7 +28,7 @@ class InterpolatedConfig(ScoringMethodConfig):
     lambda_weight: float = 0.7
 
 
-class InterpolatedSmoothing(ScoringMethod):
+class Interpolated(ScoringMethod):
     """Linear interpolation smoothing between multiple models.
 
     Combines probability estimates from different models using weighted linear
@@ -75,7 +75,7 @@ class InterpolatedSmoothing(ScoringMethod):
 
     >>> trigrams = {('the', 'big', 'cat'): 3, ('a', 'big', 'dog'): 2}
     >>> bigrams = {('big', 'cat'): 5, ('big', 'dog'): 3, ('small', 'cat'): 2}
-    >>> interp = InterpolatedSmoothing(trigrams, bigrams, lambda_weight=0.7, logprob=False)
+    >>> interp = Interpolated(trigrams, bigrams, lambda_weight=0.7, logprob=False)
     >>> interp(('the', 'big', 'cat'))
     0.5  # 0.7 * (3/5) + 0.3 * (5/10)
     >>> interp(('unseen', 'big', 'cat'))
@@ -85,7 +85,7 @@ class InterpolatedSmoothing(ScoringMethod):
 
     >>> model1 = {'word1': 10, 'word2': 5}
     >>> model2 = {'word1': 3, 'word3': 7}
-    >>> interp = InterpolatedSmoothing(model1, model2, lambda_weight=0.6, logprob=False)
+    >>> interp = Interpolated(model1, model2, lambda_weight=0.6, logprob=False)
     >>> interp('word1')
     0.48  # 0.6 * (10/15) + 0.4 * (3/10)
 

--- a/src/freqprob/performance/memory_efficient.py
+++ b/src/freqprob/performance/memory_efficient.py
@@ -197,7 +197,7 @@ class CompressedFrequencyDistribution:
         return self._total_count
 
     def get_vocabulary_size(self) -> int:
-        """Get vocabulary size."""
+        """Get support size."""
         return len(self._element_to_id)
 
     def items(self) -> Iterator[tuple[Element, int]]:

--- a/src/freqprob/performance/streaming.py
+++ b/src/freqprob/performance/streaming.py
@@ -25,7 +25,7 @@ class StreamingFrequencyDistribution:
     Parameters
     ----------
     max_vocabulary_size : Optional[int]
-        Maximum vocabulary size to maintain (None for unlimited)
+        Maximum support size to maintain (None for unlimited)
     min_count_threshold : int, default=1
         Minimum count for elements to be retained
     decay_factor : Optional[float]
@@ -57,7 +57,7 @@ class StreamingFrequencyDistribution:
         Parameters
         ----------
         max_vocabulary_size : Optional[int]
-            Maximum vocabulary size (None for unlimited)
+            Maximum support size (None for unlimited)
         min_count_threshold : int, default=1
             Minimum count threshold for retention
         decay_factor : Optional[float]
@@ -191,7 +191,7 @@ class StreamingFrequencyDistribution:
         self._total_count -= removed_count
 
     def _enforce_vocabulary_limit(self) -> None:
-        """Enforce maximum vocabulary size by removing least important elements."""
+        """Enforce maximum support size by removing least important elements."""
         if not self._max_vocab_size or len(self._counts) <= self._max_vocab_size:
             return
 
@@ -259,7 +259,7 @@ class StreamingFrequencyDistribution:
             return self._total_count
 
     def get_vocabulary_size(self) -> int:
-        """Get current vocabulary size."""
+        """Get current support size."""
         with self._lock:
             return len(self._counts)
 
@@ -280,7 +280,7 @@ class StreamingFrequencyDistribution:
             return iter(list(self._counts.values()))
 
     def __len__(self) -> int:
-        """Return vocabulary size."""
+        """Return support size."""
         return self.get_vocabulary_size()
 
     def __contains__(self, element: Element) -> bool:
@@ -377,7 +377,7 @@ class StreamingMLE(ScoringMethod, IncrementalScoringMethod):
     initial_freqdist : Optional[Dict[Element, int]]
         Initial frequency distribution
     max_vocabulary_size : Optional[int]
-        Maximum vocabulary size to maintain
+        Maximum support size to maintain
     unobs_prob : Optional[float]
         Probability mass for unobserved elements
     logprob : bool, default=True
@@ -606,7 +606,7 @@ class StreamingLaplace(StreamingMLE):
     initial_freqdist : Optional[Dict[Element, int]]
         Initial frequency distribution
     max_vocabulary_size : Optional[int]
-        Maximum vocabulary size to maintain
+        Maximum support size to maintain
     bins : Optional[int]
         Total number of possible bins
     logprob : bool, default=True
@@ -637,7 +637,7 @@ class StreamingLaplace(StreamingMLE):
         bins = getattr(self.config, "bins", None)
 
         # For Laplace smoothing, if bins is not specified, we need to consider
-        # the original vocabulary size, not just the current one
+        # the original support size, not just the current one
         if bins is None:
             bins = vocab_size
 

--- a/tests/test_freqprob.py
+++ b/tests/test_freqprob.py
@@ -662,7 +662,9 @@ def test_sgt_raises() -> None:
     # TEST_OBS1 is very simple (just ABBCCCDDDDEEEE) and won't trigger
     # RuntimeWarning with default allow_fail=True.
     # Test bins validation instead:
-    with pytest.raises(ValueError, match=r"bins .* must be greater than observed vocabulary size"):
+    with pytest.raises(
+        ValueError, match=r"bins .* must be greater than the number of observed elements"
+    ):
         # bins <= V should raise ValueError
         SimpleGoodTuring(TEST_OBS1, bins=5)  # TEST_OBS1 has 5 types, so bins=5 should fail
 

--- a/tests/test_numerical_stability.py
+++ b/tests/test_numerical_stability.py
@@ -439,7 +439,7 @@ class TestNumericalStabilityAdvanced:
             ("Laplace", {"bins": 1000}),
             ("ELE", {"bins": 1000}),
             ("Lidstone", {"gamma": 0.5, "bins": 1000}),
-            ("BayesianSmoothing", {"alpha": 0.5}),
+            ("Bayesian", {"alpha": 0.5}),
         ],
     )
     def test_method_numerical_stability(self, method_name: str, params: dict[str, Any]) -> None:

--- a/tests/test_property_based.py
+++ b/tests/test_property_based.py
@@ -198,7 +198,7 @@ class TestPropertyBasedSmoothing:
         """Test Bayesian smoothing with Dirichlet prior."""
         alpha = params["alpha"]
 
-        bayesian = freqprob.BayesianSmoothing(freq_dist, alpha=alpha, logprob=False)  # type: ignore[arg-type]
+        bayesian = freqprob.Bayesian(freq_dist, alpha=alpha, logprob=False)  # type: ignore[arg-type]
 
         # Property 1: All probabilities are positive
         for word in freq_dist:
@@ -295,7 +295,7 @@ class TestPropertyBasedSmoothing:
             lambda fd: freqprob.Laplace(fd, bins=bins, logprob=False),
             lambda fd: freqprob.ELE(fd, bins=bins, logprob=False),
             lambda fd: freqprob.Lidstone(fd, gamma=0.5, bins=bins, logprob=False),
-            lambda fd: freqprob.BayesianSmoothing(fd, alpha=0.5, logprob=False),
+            lambda fd: freqprob.Bayesian(fd, alpha=0.5, logprob=False),
         ]
 
         for method_factory in smoothing_methods:

--- a/tests/test_regression_reference.py
+++ b/tests/test_regression_reference.py
@@ -320,7 +320,7 @@ class TestScipyRegression:
         # FreqProb Bayesian smoothing (using same alpha values)
         # Note: Our alpha parameter is applied per category
         for i, category in enumerate(categories):
-            bayesian = freqprob.BayesianSmoothing(
+            bayesian = freqprob.Bayesian(
                 cast("FrequencyDistribution", freq_counts),
                 alpha=alpha[i],
                 logprob=False,

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,54 @@
+"""Tests for save()/load() serialization of fitted estimators."""
+
+import pickle
+
+import pytest
+
+import freqprob
+
+
+def _make_scorers() -> dict[str, freqprob.ScoringMethod]:
+    """Build one fitted scorer of each representative type."""
+    bigrams = {("a", "b"): 3, ("a", "c"): 1, ("b", "c"): 2}
+    return {
+        "MLE": freqprob.MLE({"a": 2, "b": 1}, logprob=False),
+        "Laplace": freqprob.Laplace({"a": 3, "b": 2, "c": 1}, bins=100, logprob=False),
+        "KneserNey": freqprob.KneserNey(bigrams, discount=0.5, logprob=False),
+        "SimpleGoodTuring": freqprob.SimpleGoodTuring(
+            {"a": 3, "b": 2, "c": 1, "d": 1}, logprob=False
+        ),
+        "Interpolated": freqprob.Interpolated(
+            {("a", "b", "c"): 3}, {("b", "c"): 5}, lambda_weight=0.7, logprob=False
+        ),
+        "Bayesian": freqprob.Bayesian({"a": 2, "b": 1}, alpha=1.0, logprob=False),
+    }
+
+
+@pytest.mark.parametrize("name", list(_make_scorers().keys()))
+def test_save_load_round_trip(name: str, tmp_path) -> None:
+    """A saved scorer reloads to the same type and produces identical scores."""
+    scorer = _make_scorers()[name]
+    path = tmp_path / f"{name}.pkl"
+
+    scorer.save(path)
+    restored = type(scorer).load(path)
+
+    assert type(restored) is type(scorer)
+    for element in [*scorer._prob, "definitely-unseen-element"]:
+        assert restored(element) == scorer(element)
+
+
+def test_load_wrong_type_raises(tmp_path) -> None:
+    """Loading via the wrong subclass raises TypeError."""
+    path = tmp_path / "m.pkl"
+    freqprob.MLE({"a": 1}, logprob=False).save(path)
+    with pytest.raises(TypeError):
+        freqprob.KneserNey.load(path)
+
+
+def test_plain_pickle_also_works() -> None:
+    """A fitted scorer round-trips through plain pickle as well."""
+    scorer = freqprob.Laplace({"a": 3, "b": 1}, bins=10, logprob=False)
+    restored = pickle.loads(pickle.dumps(scorer))
+    assert restored("a") == scorer("a")
+    assert restored("unseen") == scorer("unseen")

--- a/tests/test_sklearn_api.py
+++ b/tests/test_sklearn_api.py
@@ -4,18 +4,21 @@ import freqprob
 
 
 def test_score_matches_call() -> None:
+    """score() returns the same value as calling the scorer."""
     scorer = freqprob.MLE({"a": 2, "b": 1}, logprob=False)
     for element in ["a", "b", "unseen"]:
         assert scorer.score(element) == scorer(element)
 
 
 def test_predict_matches_per_element_calls() -> None:
+    """predict() equals scoring each element individually."""
     scorer = freqprob.Laplace({"a": 3, "b": 2, "c": 1}, bins=100, logprob=False)
     elements = ["a", "b", "c", "unseen"]
     assert scorer.predict(elements) == [scorer(e) for e in elements]
 
 
 def test_predict_preserves_order_and_length() -> None:
+    """predict() preserves input order and length."""
     scorer = freqprob.MLE({"x": 1, "y": 1}, logprob=False)
     elements = ["y", "x", "y", "z"]
     result = scorer.predict(elements)
@@ -24,6 +27,7 @@ def test_predict_preserves_order_and_length() -> None:
 
 
 def test_fit_returns_self_for_chaining() -> None:
+    """fit() returns self so calls can be chained."""
     # Fresh instance fitted via the documented chaining pattern.
     scorer = freqprob.MLE({})
     assert scorer.fit({"a": 2, "b": 1}) is scorer

--- a/tests/test_sklearn_api.py
+++ b/tests/test_sklearn_api.py
@@ -1,0 +1,30 @@
+"""Tests for the scikit-learn-style fit/predict/score aliases."""
+
+import freqprob
+
+
+def test_score_matches_call() -> None:
+    scorer = freqprob.MLE({"a": 2, "b": 1}, logprob=False)
+    for element in ["a", "b", "unseen"]:
+        assert scorer.score(element) == scorer(element)
+
+
+def test_predict_matches_per_element_calls() -> None:
+    scorer = freqprob.Laplace({"a": 3, "b": 2, "c": 1}, bins=100, logprob=False)
+    elements = ["a", "b", "c", "unseen"]
+    assert scorer.predict(elements) == [scorer(e) for e in elements]
+
+
+def test_predict_preserves_order_and_length() -> None:
+    scorer = freqprob.MLE({"x": 1, "y": 1}, logprob=False)
+    elements = ["y", "x", "y", "z"]
+    result = scorer.predict(elements)
+    assert len(result) == len(elements)
+    assert result[0] == result[2]  # both "y"
+
+
+def test_fit_returns_self_for_chaining() -> None:
+    # Fresh instance fitted via the documented chaining pattern.
+    scorer = freqprob.MLE({})
+    assert scorer.fit({"a": 2, "b": 1}) is scorer
+    assert scorer.score("a") == scorer("a")

--- a/tests/test_smoothing.py
+++ b/tests/test_smoothing.py
@@ -5,8 +5,8 @@ import pytest
 
 # Import the library to test
 from freqprob import (
-    BayesianSmoothing,
-    InterpolatedSmoothing,
+    Bayesian,
+    Interpolated,
     KneserNey,
     ModifiedKneserNey,
 )
@@ -120,7 +120,7 @@ def test_interpolated_smoothing_basic() -> None:
     high_order = {"trigram_1": 3, "trigram_2": 2, "trigram_3": 1}
     low_order = {"bigram_1": 5, "bigram_2": 3, "trigram_1": 1}  # Some overlap
 
-    interp = InterpolatedSmoothing(high_order, low_order, lambda_weight=0.7, logprob=False)  # type: ignore[arg-type]
+    interp = Interpolated(high_order, low_order, lambda_weight=0.7, logprob=False)  # type: ignore[arg-type]
 
     # Test element that appears in both distributions
     prob_common = interp("trigram_1")
@@ -145,10 +145,10 @@ def test_interpolated_smoothing_weights() -> None:
     low_order = {"common": 1}
 
     # Test with high weight on high-order model
-    interp_high = InterpolatedSmoothing(high_order, low_order, lambda_weight=0.9, logprob=False)  # type: ignore[arg-type]
+    interp_high = Interpolated(high_order, low_order, lambda_weight=0.9, logprob=False)  # type: ignore[arg-type]
 
     # Test with high weight on low-order model
-    interp_low = InterpolatedSmoothing(high_order, low_order, lambda_weight=0.1, logprob=False)  # type: ignore[arg-type]
+    interp_low = Interpolated(high_order, low_order, lambda_weight=0.1, logprob=False)  # type: ignore[arg-type]
 
     # Both should give same result for this balanced case
     prob_high = interp_high("common")
@@ -163,10 +163,10 @@ def test_interpolated_smoothing_validation() -> None:
     low_order = {"b": 1}
 
     with pytest.raises(ValueError, match=r"Lambda.*between.*0.*1"):
-        InterpolatedSmoothing(high_order, low_order, lambda_weight=-0.1)  # type: ignore[arg-type]
+        Interpolated(high_order, low_order, lambda_weight=-0.1)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match=r"Lambda.*between.*0.*1"):
-        InterpolatedSmoothing(high_order, low_order, lambda_weight=1.1)  # type: ignore[arg-type]
+        Interpolated(high_order, low_order, lambda_weight=1.1)  # type: ignore[arg-type]
 
 
 def test_interpolated_ngram_trigram_bigram() -> None:
@@ -182,7 +182,7 @@ def test_interpolated_ngram_trigram_bigram() -> None:
         ("small", "cat"): 2,
     }
 
-    interp = InterpolatedSmoothing(trigrams, bigrams, lambda_weight=0.7, logprob=False)  # type: ignore[arg-type]
+    interp = Interpolated(trigrams, bigrams, lambda_weight=0.7, logprob=False)  # type: ignore[arg-type]
 
     # Test observed trigram with observed bigram context
     prob_observed = interp(("the", "big", "cat"))
@@ -214,7 +214,7 @@ def test_interpolated_ngram_4gram_trigram() -> None:
         ("big", "red", "dog"): 2,
     }
 
-    interp = InterpolatedSmoothing(fourgrams, trigrams, lambda_weight=0.6, logprob=False)  # type: ignore[arg-type]
+    interp = Interpolated(fourgrams, trigrams, lambda_weight=0.6, logprob=False)  # type: ignore[arg-type]
 
     prob = interp(("the", "big", "red", "cat"))
     assert prob > 0
@@ -228,7 +228,7 @@ def test_interpolated_same_type_backward_compat() -> None:
     high_order = {"word1": 3, "word2": 2}
     low_order = {"word1": 1, "word3": 4}
 
-    interp = InterpolatedSmoothing(high_order, low_order, lambda_weight=0.7, logprob=False)  # type: ignore[arg-type]
+    interp = Interpolated(high_order, low_order, lambda_weight=0.7, logprob=False)  # type: ignore[arg-type]
 
     # word1 appears in both
     prob_word1 = interp("word1")
@@ -242,7 +242,7 @@ def test_interpolated_same_length_tuples() -> None:
     high_order = {("a", "b"): 3, ("c", "d"): 2}
     low_order = {("a", "b"): 1, ("e", "f"): 4}
 
-    interp = InterpolatedSmoothing(high_order, low_order, lambda_weight=0.5, logprob=False)  # type: ignore[arg-type]
+    interp = Interpolated(high_order, low_order, lambda_weight=0.5, logprob=False)  # type: ignore[arg-type]
 
     prob = interp(("a", "b"))
     assert prob > 0
@@ -257,7 +257,7 @@ def test_interpolated_ngram_order_validation() -> None:
 
     # Should raise: high-order (2) must be > low-order (3)
     with pytest.raises(ValueError, match=r"must be greater than"):
-        InterpolatedSmoothing(bigrams, trigrams, lambda_weight=0.7)  # type: ignore[arg-type]
+        Interpolated(bigrams, trigrams, lambda_weight=0.7)  # type: ignore[arg-type]
 
 
 def test_interpolated_inconsistent_lengths() -> None:
@@ -266,7 +266,7 @@ def test_interpolated_inconsistent_lengths() -> None:
     other = {("x", "y"): 1}
 
     with pytest.raises(ValueError, match=r"Inconsistent tuple lengths"):
-        InterpolatedSmoothing(mixed, other, lambda_weight=0.7)  # type: ignore[arg-type]
+        Interpolated(mixed, other, lambda_weight=0.7)  # type: ignore[arg-type]
 
 
 def test_interpolated_ngram_lambda_effect() -> None:
@@ -275,12 +275,12 @@ def test_interpolated_ngram_lambda_effect() -> None:
     bigrams = {("b", "c"): 6}
 
     # High lambda: favor trigrams
-    interp_high = InterpolatedSmoothing(trigrams, bigrams, lambda_weight=0.9, logprob=False)  # type: ignore[arg-type]
+    interp_high = Interpolated(trigrams, bigrams, lambda_weight=0.9, logprob=False)  # type: ignore[arg-type]
     prob_high = interp_high(("a", "b", "c"))
     # Should be: 0.9 * (4/4) + 0.1 * (6/6) = 0.9 + 0.1 = 1.0
 
     # Low lambda: favor bigrams
-    interp_low = InterpolatedSmoothing(trigrams, bigrams, lambda_weight=0.1, logprob=False)  # type: ignore[arg-type]
+    interp_low = Interpolated(trigrams, bigrams, lambda_weight=0.1, logprob=False)  # type: ignore[arg-type]
     prob_low = interp_low(("a", "b", "c"))
     # Should be: 0.1 * (4/4) + 0.9 * (6/6) = 0.1 + 0.9 = 1.0
 
@@ -291,7 +291,7 @@ def test_interpolated_ngram_lambda_effect() -> None:
 
 def test_bayesian_smoothing_basic() -> None:
     """Test basic Bayesian smoothing functionality."""
-    bayes = BayesianSmoothing(SIMPLE_DATA, alpha=1.0, logprob=False)  # type: ignore[arg-type]
+    bayes = Bayesian(SIMPLE_DATA, alpha=1.0, logprob=False)  # type: ignore[arg-type]
 
     # Test observed elements
     prob_apple = bayes("apple")  # (6+1)/(10+3*1) = 7/13
@@ -307,10 +307,10 @@ def test_bayesian_smoothing_basic() -> None:
 def test_bayesian_smoothing_alpha_effects() -> None:
     """Test that different alpha values affect smoothing strength."""
     # Minimal smoothing
-    bayes_min = BayesianSmoothing(SIMPLE_DATA, alpha=0.1, logprob=False)  # type: ignore[arg-type]
+    bayes_min = Bayesian(SIMPLE_DATA, alpha=0.1, logprob=False)  # type: ignore[arg-type]
 
     # Strong smoothing
-    bayes_strong = BayesianSmoothing(SIMPLE_DATA, alpha=5.0, logprob=False)  # type: ignore[arg-type]
+    bayes_strong = Bayesian(SIMPLE_DATA, alpha=5.0, logprob=False)  # type: ignore[arg-type]
 
     prob_common_min = bayes_min("apple")
     prob_unseen_min = bayes_min("unseen")
@@ -326,7 +326,7 @@ def test_bayesian_smoothing_alpha_effects() -> None:
 
 def test_bayesian_smoothing_logprob() -> None:
     """Test Bayesian smoothing with log-probabilities."""
-    bayes = BayesianSmoothing(SIMPLE_DATA, alpha=1.0, logprob=True)  # type: ignore[arg-type]
+    bayes = Bayesian(SIMPLE_DATA, alpha=1.0, logprob=True)  # type: ignore[arg-type]
 
     log_prob = bayes("apple")
     assert log_prob < 0
@@ -339,18 +339,18 @@ def test_bayesian_smoothing_logprob() -> None:
 def test_bayesian_smoothing_validation() -> None:
     """Test that Bayesian smoothing validates alpha parameter."""
     with pytest.raises(ValueError, match=r"Alpha.*positive"):
-        BayesianSmoothing(SIMPLE_DATA, alpha=0.0)  # type: ignore[arg-type]
+        Bayesian(SIMPLE_DATA, alpha=0.0)  # type: ignore[arg-type]
 
     with pytest.raises(ValueError, match=r"Alpha.*positive"):
-        BayesianSmoothing(SIMPLE_DATA, alpha=-1.0)  # type: ignore[arg-type]
+        Bayesian(SIMPLE_DATA, alpha=-1.0)  # type: ignore[arg-type]
 
 
 def test_all_methods_string_representation() -> None:
     """Test that all methods have proper string representation."""
     kn = KneserNey(BIGRAM_DATA)  # type: ignore[arg-type]
     mkn = ModifiedKneserNey(BIGRAM_DATA)  # type: ignore[arg-type]
-    interp = InterpolatedSmoothing({"a": 1}, {"b": 1})
-    bayes = BayesianSmoothing(SIMPLE_DATA)  # type: ignore[arg-type]
+    interp = Interpolated({"a": 1}, {"b": 1})
+    bayes = Bayesian(SIMPLE_DATA)  # type: ignore[arg-type]
 
     assert "Kneser-Ney" in str(kn)
     assert "Modified Kneser-Ney" in str(mkn)
@@ -390,7 +390,7 @@ def test_consistency_with_traditional_methods() -> None:
     from freqprob import Laplace
 
     # For unigram data, Bayesian with alpha=1 should match Laplace
-    bayes = BayesianSmoothing(SIMPLE_DATA, alpha=1.0, logprob=False)  # type: ignore[arg-type]
+    bayes = Bayesian(SIMPLE_DATA, alpha=1.0, logprob=False)  # type: ignore[arg-type]
     laplace = Laplace(SIMPLE_DATA, logprob=False)  # type: ignore[arg-type]
 
     # Test observed elements
@@ -407,7 +407,7 @@ def test_consistency_with_traditional_methods() -> None:
 
 def test_probability_normalization() -> None:
     """Test that probabilities are reasonable (don't test exact normalization)."""
-    bayes = BayesianSmoothing(SIMPLE_DATA, alpha=1.0, logprob=False)  # type: ignore[arg-type]
+    bayes = Bayesian(SIMPLE_DATA, alpha=1.0, logprob=False)  # type: ignore[arg-type]
 
     # Test that all probabilities are positive and reasonable
     for element in SIMPLE_DATA:

--- a/tests/test_statistical_correctness.py
+++ b/tests/test_statistical_correctness.py
@@ -125,7 +125,7 @@ class TestStatisticalCorrectness:
         counts = {"term1": 40, "term2": 30, "term3": 20, "term4": 10}
 
         for alpha in [0.1, 0.5, 1.0, 2.0]:
-            bayesian = freqprob.BayesianSmoothing(counts, alpha=alpha, logprob=False)  # type: ignore[arg-type]
+            bayesian = freqprob.Bayesian(counts, alpha=alpha, logprob=False)  # type: ignore[arg-type]
 
             total_count = sum(counts.values())
             vocab_size = len(counts)
@@ -137,7 +137,7 @@ class TestStatisticalCorrectness:
                 assert abs(actual - expected) < 1e-15
 
         # Test that alpha=1 gives uniform prior (similar to Laplace)
-        bayesian_1 = freqprob.BayesianSmoothing(counts, alpha=1.0, logprob=False)  # type: ignore[arg-type]
+        bayesian_1 = freqprob.Bayesian(counts, alpha=1.0, logprob=False)  # type: ignore[arg-type]
 
         # Should sum to 1 for observed vocabulary
         total_prob = sum(bayesian_1(word) for word in counts)
@@ -152,7 +152,7 @@ class TestStatisticalCorrectness:
             freqprob.Laplace(counts, bins=100, logprob=False),  # type: ignore[arg-type]
             freqprob.ELE(counts, bins=100, logprob=False),  # type: ignore[arg-type]
             freqprob.Lidstone(counts, gamma=0.5, bins=100, logprob=False),  # type: ignore[arg-type]
-            freqprob.BayesianSmoothing(counts, alpha=0.5, logprob=False),  # type: ignore[arg-type]
+            freqprob.Bayesian(counts, alpha=0.5, logprob=False),  # type: ignore[arg-type]
             freqprob.Uniform(counts, unobs_prob=0.1, logprob=False),  # type: ignore[arg-type]
         ]
 
@@ -483,7 +483,7 @@ class TestAdvancedStatisticalProperties:
         }
 
         for lambda_weight in [0.1, 0.3, 0.5, 0.7, 0.9]:
-            interpolated = freqprob.InterpolatedSmoothing(
+            interpolated = freqprob.Interpolated(
                 high_order, low_order, lambda_weight=lambda_weight, logprob=False
             )
 
@@ -599,7 +599,7 @@ class TestAdvancedStatisticalProperties:
             ("Laplace", {"bins": 100}),
             ("ELE", {"bins": 100}),
             ("Lidstone", {"gamma": 0.5, "bins": 100}),
-            ("BayesianSmoothing", {"alpha": 0.5}),
+            ("Bayesian", {"alpha": 0.5}),
             ("Uniform", {"unobs_prob": 0.1}),
         ],
     )


### PR DESCRIPTION
## Summary

Phase 5, the final phase of the architectural revision — the deliberate **public-API pass**, plus the `save()`/`load()` feature, released as **0.6.0**. Unlike Phases 1–4, this one intentionally changes the public surface (two class renames); everything else is additive.

Five focused commits:

## 1. Breaking: renamed estimator classes (`refactor!`)
Dropped the inconsistent `Smoothing` suffix so all estimator names are uniform:
- `BayesianSmoothing` → `Bayesian`
- `InterpolatedSmoothing` → `Interpolated`

Constructor parameters and behavior are unchanged. Updated across source, tests, docs, and README.

## 2. scikit-learn-style aliases (additive)
`fit()` / `predict()` / `score()` on every estimator, alongside the existing callable contract:
- `score(element)` — single-element alias for `__call__`
- `predict(elements)` — batch scoring over an iterable
- `fit(freqdist)` — already existed, returns `self`

## 3. Terminology neutralization (cosmetic)
Docstring prose and the one runtime error message shifted from `vocabulary size` → `support size`, matching the general-purpose framing. Public identifiers that contain `vocabulary` (`max_vocabulary_size` param, `get_vocabulary_size()` method) are intentionally left unchanged — no gratuitous breakage.

## 4. Model serialization (feature)
`save(path)` / `load(path)` on `ScoringMethod` to persist and restore a fitted estimator without re-fitting:
```python
scorer.save("model.pkl")
restored = freqprob.KneserNey.load("model.pkl")
```
Implemented with explicit `__getstate__`/`__setstate__` so the `__slots__` hierarchy serializes reliably across Python versions; `load()` validates the object type and documents the trust requirement of unpickling. Also **exports the `ScoringMethod` base type** publicly (for `isinstance`/type hints).

## 5. Release prep → 0.6.0
- `__version__` → `0.6.0`; version updated in `CITATION.cff` and the README citation.
- **`MIGRATION.md`** — old→new class names and the internal-module-path moves, with the "import from the top-level namespace" guidance.
- `CHANGELOG.md` — accumulated `[Unreleased]` entries (Phases 1–5) consolidated into a `[0.6.0]` section with a **breaking-changes** callout.
- README interface example now shows `predict`/`save`/`load`.

## Verification (local)
- `ruff check` / `ruff format --check` — clean · `mypy` — clean · `mkdocs build --strict` — clean
- `pytest` — **241 passed, 5 skipped, 83.62% coverage** (adds parametrized round-trip tests for save/load across 6 estimator types, plus alias tests)
- Save/load round-trips verified for MLE, Laplace, KneserNey, SimpleGoodTuring, Interpolated, Bayesian; the `TypeError` guard and plain-`pickle` path tested.

## Releasing 0.6.0
After merge, tag `v0.6.0` to trigger the release workflow. Reminder: the PyPI **trusted publisher** must be configured first (owner `tresoldi`, repo `freqprob`, workflow `release.yml`, environment `pypi`), or the publish step will fail.

This completes all five phases from `ARCHITECTURE.md`. 🎉

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_