### PR TITLE
fix: make re-fitting an estimator behave like a fresh fit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.6.0] - 2026-07-24
 
+### Fixed
+
+- **Re-fitting an estimator**: Calling `fit()` a second time on an already-fitted
+  estimator now behaves identically to a fresh fit. Previously, log-space methods
+  (`MLE`, `Uniform`, `Random`, `CertaintyDegree`) could raise a `math domain error`
+  because `self._unobs` — which holds the previous *output* — was reused as an epsilon
+  floor; and methods that build `self._prob` incrementally (`KneserNey`,
+  `SimpleGoodTuring`) left stale keys from the previous data. `fit()` now resets state
+  first, and the additive-floor methods use a fixed `MIN_PROBABILITY` constant.
+
 ### Changed - BREAKING
 
 - **Renamed estimator classes** (dropped the inconsistent `Smoothing` suffix):

--- a/src/freqprob/base.py
+++ b/src/freqprob/base.py
@@ -18,6 +18,11 @@ Probability = float
 LogProbability = float
 FrequencyDistribution = Mapping[Element, Count]
 
+# Smallest probability used as a floor to avoid log(0) domain errors. Kept as a
+# module constant so methods can use it directly rather than reading `_unobs`
+# (which holds the *output* value and would be wrong on a second fit()).
+MIN_PROBABILITY: Probability = 1e-10
+
 # Generic type variable for method chaining
 T = TypeVar("T", bound="ScoringMethod")
 
@@ -139,7 +144,7 @@ class ScoringMethod(ABC):
         """
         self.config: ScoringMethodConfig = config
 
-        self._unobs: Probability | LogProbability = 1e-10  # Default value to avoid domain errors
+        self._unobs: Probability | LogProbability = MIN_PROBABILITY  # avoid domain errors
         self._prob: dict[Element, Probability | LogProbability] = {}
         self._total_unseen_mass: float | None = (
             None  # For methods that track total unseen mass (e.g., SGT)
@@ -242,6 +247,13 @@ class ScoringMethod(ABC):
         >>> scorer('a')
         0.6666666666666666
         """
+        # Reset state so re-fitting an already-fitted scorer behaves like a
+        # fresh fit: methods that assign into self._prob incrementally would
+        # otherwise leave stale keys, and self._unobs (which holds the previous
+        # output) would otherwise pollute epsilon floors on a second fit.
+        self._prob = {}
+        self._unobs = MIN_PROBABILITY
+        self._total_unseen_mass = None
         self._compute_probabilities(freqdist)
 
         return self

--- a/src/freqprob/methods/baselines.py
+++ b/src/freqprob/methods/baselines.py
@@ -10,7 +10,13 @@ import math
 import random
 from dataclasses import dataclass
 
-from freqprob.base import FrequencyDistribution, Probability, ScoringMethod, ScoringMethodConfig
+from freqprob.base import (
+    MIN_PROBABILITY,
+    FrequencyDistribution,
+    Probability,
+    ScoringMethod,
+    ScoringMethodConfig,
+)
 
 
 @dataclass
@@ -108,7 +114,7 @@ class Uniform(ScoringMethod):
 
         if self.logprob:
             # Avoid domain errors by ensuring unobs_prob >= machine epsilon
-            unobs_prob = max(unobs_prob, self._unobs)
+            unobs_prob = max(unobs_prob, MIN_PROBABILITY)
             uniform_prob = (1.0 - unobs_prob) / vocab_size
             log_uniform_prob = math.log(uniform_prob)
             self._prob = dict.fromkeys(freqdist, log_uniform_prob)
@@ -208,7 +214,7 @@ class Random(ScoringMethod):
         total_random_counts = sum(random_counts.values())
 
         if self.logprob:
-            unobs_prob = max(unobs_prob, self._unobs)  # Avoid domain errors
+            unobs_prob = max(unobs_prob, MIN_PROBABILITY)  # Avoid domain errors
             available_mass = 1.0 - unobs_prob
             self._prob = {
                 elem: math.log((count / total_random_counts) * available_mass)
@@ -327,7 +333,7 @@ class MLE(ScoringMethod):
         available_mass = 1.0 - unobs_prob
 
         if self.logprob:
-            unobs_prob = max(unobs_prob, self._unobs)  # Avoid domain errors
+            unobs_prob = max(unobs_prob, MIN_PROBABILITY)  # Avoid domain errors
             self._prob = {
                 elem: math.log((count / total_count) * available_mass)
                 for elem, count in freqdist.items()

--- a/src/freqprob/methods/certainty.py
+++ b/src/freqprob/methods/certainty.py
@@ -2,7 +2,13 @@
 
 import math
 
-from freqprob.base import FrequencyDistribution, Probability, ScoringMethod, ScoringMethodConfig
+from freqprob.base import (
+    MIN_PROBABILITY,
+    FrequencyDistribution,
+    Probability,
+    ScoringMethod,
+    ScoringMethodConfig,
+)
 from freqprob.cache import cached_computation
 
 
@@ -74,10 +80,9 @@ class CertaintyDegree(ScoringMethod):
         # between 1.0 discounted the calculated mass and 1.0 discounted the
         # minimum mass probability reserved.
         if self.logprob:
-            # Ensure unobs_prob is not None and handle self._unobs initialization
-            unobs_prob = unobs_prob or 0.0
-            current_unobs = getattr(self, "_unobs", 0.0) or 0.0
-            unobs_prob = max(unobs_prob, current_unobs)
+            # Floor the reserved mass with a fixed epsilon (not self._unobs, which
+            # holds the previous output and would be stale on a second fit()).
+            unobs_prob = max(unobs_prob or 0.0, MIN_PROBABILITY)
             prob_space = min(1.0 - (b / (z + 1)) ** n, 1.0 - unobs_prob)
             self._prob = {
                 sample: math.log((count / n) * prob_space) for sample, count in freqdist.items()

--- a/tests/test_refit.py
+++ b/tests/test_refit.py
@@ -1,0 +1,67 @@
+"""Re-fitting an estimator must behave identically to a fresh fit on the same data."""
+
+# mypy: disable-error-code="arg-type,no-untyped-def"
+
+import pytest
+
+import freqprob
+
+# data B differs from data A: some shared keys, some A-only, some B-only
+DATA_A = {"a": 5, "b": 3, "c": 2}
+DATA_B = {"b": 4, "c": 1, "d": 6, "e": 2}
+PROBE = ["a", "b", "c", "d", "e", "unseen"]
+
+# Chosen so a stale (c, w1) key from A (~0.333) differs from B's unseen mass
+# (~0.5), making the stale-key bug observable rather than coincidentally masked.
+BIGRAMS_A = {("c", "w1"): 1, ("c", "w2"): 1, ("c", "w3"): 1}
+BIGRAMS_B = {("x", "b"): 5, ("y", "b"): 2, ("z", "d"): 1}
+BIGRAM_PROBE = [("c", "w1"), ("x", "b"), ("z", "d"), ("q", "q")]
+
+
+def _refit(factory, data_a, data_b):
+    """Return a scorer built on A then re-fit on B, forcing a real recompute.
+
+    Caches are cleared before the re-fit so the second fit(B) is a cache miss
+    that actually re-runs _compute_probabilities on top of A's state (this is
+    what surfaces stale-key bugs; a cache hit would mask them).
+    """
+    scorer = factory(data_a)
+    freqprob.clear_all_caches()
+    scorer.fit(data_b)
+    return scorer
+
+
+@pytest.mark.parametrize(
+    ("factory", "data_a", "data_b", "probe"),
+    [
+        (lambda d: freqprob.MLE(d, logprob=False), DATA_A, DATA_B, PROBE),
+        (lambda d: freqprob.Uniform(d, logprob=False), DATA_A, DATA_B, PROBE),
+        (lambda d: freqprob.Laplace(d, bins=100, logprob=False), DATA_A, DATA_B, PROBE),
+        (lambda d: freqprob.Lidstone(d, gamma=0.5, bins=100, logprob=False), DATA_A, DATA_B, PROBE),
+        (lambda d: freqprob.ELE(d, bins=100, logprob=False), DATA_A, DATA_B, PROBE),
+        (lambda d: freqprob.Bayesian(d, alpha=1.0, logprob=False), DATA_A, DATA_B, PROBE),
+        (lambda d: freqprob.CertaintyDegree(d, logprob=False), DATA_A, DATA_B, PROBE),
+        (lambda d: freqprob.WittenBell(d, logprob=False), DATA_A, DATA_B, PROBE),
+        (lambda d: freqprob.SimpleGoodTuring(d, logprob=False), DATA_A, DATA_B, PROBE),
+        (
+            lambda d: freqprob.KneserNey(d, discount=0.5, logprob=False),
+            BIGRAMS_A,
+            BIGRAMS_B,
+            BIGRAM_PROBE,
+        ),
+    ],
+)
+def test_refit_matches_fresh_fit(factory, data_a, data_b, probe) -> None:
+    """Fitting on A then B must equal a fresh estimator fitted only on B."""
+    freqprob.clear_all_caches()
+    fresh = factory(data_b)
+    refit = _refit(factory, data_a, data_b)
+    for element in probe:
+        assert refit(element) == pytest.approx(fresh(element)), f"mismatch at {element!r}"
+
+
+def test_refit_logprob_does_not_raise() -> None:
+    """Re-fitting in log-space must not raise a math domain error (the reported bug)."""
+    scorer = freqprob.MLE({"a": 1})  # logprob=True by default
+    scorer.fit({"a": 2, "b": 1})  # must not raise
+    assert scorer.score("a") == scorer("a")


### PR DESCRIPTION
## Summary

Fixes the latent re-fit bug flagged during Phase 5. Calling `fit()` a **second time** on an already-fitted estimator was broken in two ways; both are now fixed, with a comprehensive regression test.

## The bugs

1. **`math domain error` in log space** — `MLE`, `Uniform`, `Random`, `CertaintyDegree` used `self._unobs` as an epsilon floor (`max(unobs_prob, self._unobs)`), but `self._unobs` *also* stores the final log-probability output. On a second fit it held a negative log value, so `max(0.0, -23) = 0.0` → `log(0)` → crash.
2. **Stale keys** — `KneserNey` and `SimpleGoodTuring` build `self._prob` by item-assignment without resetting it, so a re-fit left keys from the *previous* distribution and scored old-only elements with old values. This was partly **masked** by `@cached_computation` (which also cached the polluted dict) and partly by `_unobs` coincidentally equaling the stale value — the investigation is in the commit history.

## The fix

- **`ScoringMethod.fit()` resets state** (`_prob`, `_unobs`, `_total_unseen_mass`) before `_compute_probabilities`, so every fit starts clean — a single, universal fix that also keeps cached results clean (they're now computed from a clean slate).
- Added a **`MIN_PROBABILITY`** constant in `base` and used it as the additive floor in `baselines`/`certainty`, instead of reading `self._unobs` (self-documenting; independent of the reset).

## Regression test (`tests/test_refit.py`)

For **every** estimator: `fit(A)` then `fit(B)` must equal a fresh estimator fitted only on `B`. Made genuinely rigorous:
- **caches cleared** before the re-fit so it's a real cache-miss recompute (a cache hit would mask the bug), and
- bigram data chosen so a stale key (~0.333) differs from `B`'s unseen mass (~0.5) — I verified the test **fails on the old code** (`0.333 ≠ 0.500`) and **passes on the fix**.

## Verification

- `ruff` + `ruff format` + `mypy` clean (32 files)
- **252 passed, 5 skipped, 83.62% coverage** (+11 re-fit cases)

## Versioning note

0.6.0 is merged to `main` but (as far as I know) not yet tagged/released to PyPI, so I folded this fix into the `[0.6.0]` CHANGELOG section — tagging `v0.6.0` will include it. **If you already tagged/released 0.6.0**, tell me and I'll re-label this as `[0.6.1]` and bump `__version__` before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_