### PR TITLE
release: prepare 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-07-28
+
+Maintenance release: test-coverage and CI hardening only. No library code or
+public API changes since 0.6.0.
+
 ### Added
 
 - **Test coverage for the performance helpers**: new `tests/test_profiling.py`
@@ -14,11 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   branches of `performance/profiling.py` (69% → 96%), `performance/vectorized.py`
   (70% → 100%), and `performance/lazy.py` (78% → 99%), raising overall coverage
   from ~84% to ~91%.
+- **CI security scanning**: the quality workflow now runs `bandit` against
+  `src/` on every push and pull request (configuration already lived in
+  `pyproject.toml`).
+- **CI coverage reporting**: the test workflow uploads coverage to Codecov once
+  per run (from the Ubuntu / Python 3.12 matrix cell), using the existing
+  `codecov.yml` configuration.
 
 ### Changed
 
-- Raised the enforced coverage floor in `pyproject.toml` from 80% to 88% to lock
-  in the higher coverage.
+- Raised the enforced coverage floor from 80% to 88% (in both `pyproject.toml`
+  and the CI workflow) to lock in the higher coverage.
 
 ## [0.6.0] - 2026-07-24
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -12,7 +12,8 @@ authors:
     given-names: Tiago
     affiliation: "Department of Linguistics and Philology, Uppsala University"
     email: tiago.tresoldi@lingfil.uu.se
-version: 0.6.0
+version: 0.6.1
+date-released: 2026-07-28
 license: MIT
 repository-code: "https://github.com/tresoldi/freqprob"
 url: "https://github.com/tresoldi/freqprob"

--- a/src/freqprob/__init__.py
+++ b/src/freqprob/__init__.py
@@ -1,7 +1,7 @@
 """FreqProb: frequency-based probability estimation library."""
 
 # Version of the freqprob package
-__version__ = "0.6.0"
+__version__ = "0.6.1"
 __author__ = "Tiago Tresoldi"
 __email__ = "tiago.tresoldi@lingfil.uu.se"
 


### PR DESCRIPTION
## Summary

Prepares the **0.6.1** maintenance release. This bundles the test-coverage and
CI-hardening work merged since 0.6.0 — **no library code or public API changes**.

## Changes

- **Version bump** `0.6.0` → `0.6.1` in `src/freqprob/__init__.py` (the single
  source of truth; `pyproject.toml` reads it dynamically via
  `[tool.setuptools.dynamic]`).
- **`CITATION.cff`**: version bumped and a `date-released: 2026-07-28` field added.
- **CHANGELOG**: cut the dated `[0.6.1] - 2026-07-28` section from `[Unreleased]`
  and left a fresh empty `[Unreleased]`. The section records everything since
  0.6.0 — the performance-helper coverage backfill, the bandit CI scan, the
  Codecov upload, and the 80% → 88% coverage-floor bump.

## Verification

- `python -m build` produces `freqprob-0.6.1.tar.gz` and
  `freqprob-0.6.1-py3-none-any.whl`.
- `import freqprob; freqprob.__version__` → `0.6.1`.
- Full suite: 315 passed, 5 skipped, 90.9% coverage (≥ 88% floor); ruff + mypy clean.

## Release steps (after merge)

Tag `v0.6.1` on `main` and push it — the tag-triggered `release.yml` builds and
publishes to PyPI via trusted publishing (OIDC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_