### PR TITLE
build(deps-dev): bump ruff to 0.16.0 and mypy to 2.3.0 (supersedes #27, #28)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ repos:
       - id: check-merge-conflict
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.8
+    rev: v0.16.0
     hooks:
       # Linter (matches `ruff check .`)
       - id: ruff
@@ -22,7 +22,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v2.3.0
     hooks:
       - id: mypy
         files: ^(src/freqprob|tests|scripts)/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -125,7 +125,7 @@ The estimator lifecycle:
 
 ```python
 scorer = freqprob.Laplace(freqdist, bins=..., logprob=True)
-p = scorer(element)          # __call__ scores one element
+p = scorer(element)  # __call__ scores one element
 ```
 
 - Construction fits the model; `__call__(element)` returns a probability or

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Bumped pinned dev tooling in lockstep across `pyproject.toml` and
+  `.pre-commit-config.yaml`: **ruff** `0.15.8` → `0.16.0` and **mypy**
+  `1.19.1` → `2.3.0`. Applied ruff 0.16.0's updated formatting (Markdown
+  embedded code blocks). No source-code or public API changes.
+
 ## [0.6.1] - 2026-07-28
 
 Maintenance release: test-coverage and CI hardening only. No library code or
@@ -203,18 +210,18 @@ For users upgrading from v0.3.x:
 ```python
 # v0.3.x code:
 sgt = SimpleGoodTuring(freqdist)
-p_total_unseen = sgt('unseen_word')  # Returned p₀ ≈ 0.07
+p_total_unseen = sgt("unseen_word")  # Returned p₀ ≈ 0.07
 
 # v0.4.0 equivalent:
 sgt = SimpleGoodTuring(freqdist)
-p_per_word = sgt('unseen_word')      # Returns per-word prob ≈ 0.00012
+p_per_word = sgt("unseen_word")  # Returns per-word prob ≈ 0.00012
 p_total_unseen = sgt.total_unseen_mass  # Access p₀ ≈ 0.07
 
 # If you need the old behavior (not recommended):
 # The old behavior was mathematically inconsistent. If you truly need it,
 # multiply per-word probability by estimated unseen types:
-estimated_unseen = int(sgt.total_unseen_mass / sgt('unseen_word'))
-p_approx_old = sgt('unseen_word') * estimated_unseen
+estimated_unseen = int(sgt.total_unseen_mass / sgt("unseen_word"))
+p_approx_old = sgt("unseen_word") * estimated_unseen
 ```
 
 **Why this change?**

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -22,10 +22,12 @@ uniform:
 ```python
 # Before
 from freqprob import BayesianSmoothing, InterpolatedSmoothing
+
 model = BayesianSmoothing(counts, alpha=1.0)
 
 # After
 from freqprob import Bayesian, Interpolated
+
 model = Bayesian(counts, alpha=1.0)
 ```
 
@@ -54,9 +56,9 @@ stable across these moves.
 - **scikit-learn-style aliases** on every estimator, alongside the existing
   callable contract:
   ```python
-  scorer.fit(freqdist)        # returns self
-  scorer.score(element)       # single element (alias for scorer(element))
-  scorer.predict(elements)    # batch: list of scores
+  scorer.fit(freqdist)  # returns self
+  scorer.score(element)  # single element (alias for scorer(element))
+  scorer.predict(elements)  # batch: list of scores
   ```
 - **Serialization** — persist and restore a fitted estimator without re-fitting:
   ```python

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import freqprob
 counts = {"the": 100, "cat": 50, "dog": 30, "bird": 10}
 
 laplace = freqprob.Laplace(counts, bins=10_000, logprob=False)
-laplace("cat")       # 0.0050  — an observed element
+laplace("cat")  # 0.0050  — an observed element
 laplace("elephant")  # 0.0001  — an unseen element still gets non-zero mass
 ```
 
@@ -44,13 +44,13 @@ distribution, then **call it** to score an element.
 
 ```python
 scorer = freqprob.KneserNey(bigram_counts, discount=0.75)
-scorer(("the", "cat"))                              # score one element
-scorer.predict([("the", "cat"), ("a", "dog")])      # score many (scikit-learn-style)
+scorer(("the", "cat"))  # score one element
+scorer.predict([("the", "cat"), ("a", "dog")])  # score many (scikit-learn-style)
 
-freqprob.perplexity(scorer, test_bigrams)           # evaluate a model
+freqprob.perplexity(scorer, test_bigrams)  # evaluate a model
 
-scorer.save("model.pkl")                            # persist a fitted model...
-scorer = freqprob.KneserNey.load("model.pkl")       # ...and load it back
+scorer.save("model.pkl")  # persist a fitted model...
+scorer = freqprob.KneserNey.load("model.pkl")  # ...and load it back
 ```
 
 `fit`/`predict`/`score` aliases are available for scikit-learn familiarity, and

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -75,9 +75,9 @@ MLE(freqdist: FrequencyDistribution,
 
 **Example:**
 ```python
-freqdist = {'cat': 3, 'dog': 2, 'bird': 1}
+freqdist = {"cat": 3, "dog": 2, "bird": 1}
 mle = freqprob.MLE(freqdist, logprob=False)
-print(mle('cat'))  # 0.5 (3/6)
+print(mle("cat"))  # 0.5 (3/6)
 ```
 
 **Mathematical Formula:**
@@ -107,10 +107,10 @@ Laplace(freqdist: FrequencyDistribution,
 
 **Example:**
 ```python
-freqdist = {'cat': 3, 'dog': 2, 'bird': 1}
+freqdist = {"cat": 3, "dog": 2, "bird": 1}
 laplace = freqprob.Laplace(freqdist, bins=1000, logprob=False)
-print(laplace('cat'))    # (3+1)/(6+1000) ≈ 0.004
-print(laplace('mouse'))  # (0+1)/(6+1000) ≈ 0.001
+print(laplace("cat"))  # (3+1)/(6+1000) ≈ 0.004
+print(laplace("mouse"))  # (0+1)/(6+1000) ≈ 0.001
 ```
 
 **Mathematical Formula:**
@@ -142,9 +142,9 @@ Lidstone(freqdist: FrequencyDistribution,
 
 **Example:**
 ```python
-freqdist = {'cat': 3, 'dog': 2, 'bird': 1}
+freqdist = {"cat": 3, "dog": 2, "bird": 1}
 lidstone = freqprob.Lidstone(freqdist, gamma=0.5, bins=1000, logprob=False)
-print(lidstone('cat'))  # (3+0.5)/(6+500) ≈ 0.007
+print(lidstone("cat"))  # (3+0.5)/(6+500) ≈ 0.007
 ```
 
 **Mathematical Formula:**
@@ -174,9 +174,9 @@ ELE(freqdist: FrequencyDistribution,
 
 **Example:**
 ```python
-freqdist = {'cat': 3, 'dog': 2, 'bird': 1}
+freqdist = {"cat": 3, "dog": 2, "bird": 1}
 ele = freqprob.ELE(freqdist, bins=1000, logprob=False)
-print(ele('cat'))  # (3+0.5)/(6+500) ≈ 0.007
+print(ele("cat"))  # (3+0.5)/(6+500) ≈ 0.007
 ```
 
 **Mathematical Formula:**
@@ -272,19 +272,19 @@ SimpleGoodTuring(freqdist: FrequencyDistribution,
 
 **Example:**
 ```python
-freqdist = {'cat': 3, 'dog': 2, 'bird': 1, 'fish': 1}
+freqdist = {"cat": 3, "dog": 2, "bird": 1, "fish": 1}
 try:
     # Default behavior: bins = V + N₁
     sgt = freqprob.SimpleGoodTuring(freqdist, logprob=False)
-    print(sgt('cat'))       # Probability for observed word
-    print(sgt('unknown'))   # Per-word probability for unseen word
+    print(sgt("cat"))  # Probability for observed word
+    print(sgt("unknown"))  # Per-word probability for unseen word
 
     # Access total unseen mass
     print(sgt.total_unseen_mass)  # p₀ (total mass for ALL unseen)
 
     # Custom bins for larger vocabulary
     sgt_large = freqprob.SimpleGoodTuring(freqdist, bins=10000, logprob=False)
-    print(sgt_large('unknown'))  # Smaller per-word probability
+    print(sgt_large("unknown"))  # Smaller per-word probability
 
 except ValueError:
     print("SGT failed - frequency distribution unsuitable")
@@ -309,8 +309,8 @@ instead of the total unseen mass p₀. Use the `total_unseen_mass` property to a
 
 # v0.4.0+ behavior (returns per-word probability):
 sgt = SimpleGoodTuring(freqdist)
-sgt('unseen')            # ≈ 0.00012 (per-word probability)
-sgt.total_unseen_mass    # ≈ 0.07 (same p₀ as before)
+sgt("unseen")  # ≈ 0.00012 (per-word probability)
+sgt.total_unseen_mass  # ≈ 0.07 (same p₀ as before)
 ```
 
 ---
@@ -338,12 +338,9 @@ KneserNey(freqdist: FrequencyDistribution,
 **Example:**
 ```python
 # Bigram counts: context -> word
-bigrams = {
-    ('the', 'cat'): 5, ('the', 'dog'): 3,
-    ('a', 'cat'): 2, ('a', 'dog'): 1
-}
+bigrams = {("the", "cat"): 5, ("the", "dog"): 3, ("a", "cat"): 2, ("a", "dog"): 1}
 kn = freqprob.KneserNey(bigrams, discount=0.75, logprob=False)
-print(kn(('the', 'cat')))
+print(kn(("the", "cat")))
 ```
 
 **Mathematical Formula:**
@@ -371,9 +368,9 @@ ModifiedKneserNey(freqdist: FrequencyDistribution,
 
 **Example:**
 ```python
-bigrams = {('the', 'cat'): 5, ('the', 'dog'): 3, ('a', 'cat'): 2}
+bigrams = {("the", "cat"): 5, ("the", "dog"): 3, ("a", "cat"): 2}
 mkn = freqprob.ModifiedKneserNey(bigrams, logprob=False)
-print(mkn(('the', 'cat')))
+print(mkn(("the", "cat")))
 ```
 
 **Features:**
@@ -423,17 +420,17 @@ The method automatically detects the interpolation mode:
 
 N-gram interpolation (trigrams + bigrams):
 ```python
-trigrams = {('the', 'big', 'cat'): 3, ('a', 'big', 'dog'): 2}
-bigrams = {('big', 'cat'): 5, ('big', 'dog'): 3, ('small', 'cat'): 2}
+trigrams = {("the", "big", "cat"): 3, ("a", "big", "dog"): 2}
+bigrams = {("big", "cat"): 5, ("big", "dog"): 3, ("small", "cat"): 2}
 interp = freqprob.Interpolated(trigrams, bigrams, lambda_weight=0.7, logprob=False)
-print(interp(('the', 'big', 'cat')))  # 0.57 = 0.7 * (3/5) + 0.3 * (5/10)
-print(interp(('unseen', 'big', 'cat')))  # 0.15 = 0.7 * 0 + 0.3 * (5/10)
+print(interp(("the", "big", "cat")))  # 0.57 = 0.7 * (3/5) + 0.3 * (5/10)
+print(interp(("unseen", "big", "cat")))  # 0.15 = 0.7 * 0 + 0.3 * (5/10)
 ```
 
 Same-type interpolation (strings):
 ```python
-high_freq = {'cat': 10, 'dog': 5}
-low_freq = {'cat': 3, 'dog': 2, 'bird': 1}
+high_freq = {"cat": 10, "dog": 5}
+low_freq = {"cat": 3, "dog": 2, "bird": 1}
 interp = freqprob.Interpolated(high_freq, low_freq, lambda_weight=0.8, logprob=False)
 ```
 
@@ -474,9 +471,9 @@ Bayesian(freqdist: FrequencyDistribution,
 
 **Example:**
 ```python
-freqdist = {'cat': 3, 'dog': 2, 'bird': 1}
+freqdist = {"cat": 3, "dog": 2, "bird": 1}
 bayesian = freqprob.Bayesian(freqdist, alpha=0.5, logprob=False)
-print(bayesian('cat'))
+print(bayesian("cat"))
 ```
 
 **Mathematical Formula:**
@@ -559,7 +556,7 @@ def perplexity(model: ScoringMethod,
 **Example:**
 ```python
 model = freqprob.KneserNey(bigrams, logprob=True)
-test_words = ['the', 'cat', 'sat', 'on', 'mat']
+test_words = ["the", "cat", "sat", "on", "mat"]
 pp = freqprob.perplexity(model, test_words)
 print(f"Perplexity: {pp:.2f}")
 ```
@@ -632,8 +629,8 @@ def model_comparison(models: Dict[str, ScoringMethod],
 **Example:**
 ```python
 models = {
-    'mle': freqprob.MLE(freqdist, logprob=True),
-    'laplace': freqprob.Laplace(freqdist, logprob=True)
+    "mle": freqprob.MLE(freqdist, logprob=True),
+    "laplace": freqprob.Laplace(freqdist, logprob=True),
 }
 results = freqprob.model_comparison(models, test_data)
 for name, metrics in results.items():
@@ -661,7 +658,7 @@ def generate_ngrams(tokens: List[str], n: int) -> List[Tuple[str, ...]]
 
 **Example:**
 ```python
-tokens = ['the', 'cat', 'sat']
+tokens = ["the", "cat", "sat"]
 bigrams = freqprob.generate_ngrams(tokens, 2)
 # [('<s>', 'the'), ('the', 'cat'), ('cat', 'sat'), ('sat', '</s>')]
 ```
@@ -730,7 +727,7 @@ def score_batch(self, elements: List[Element]) -> np.ndarray
 ```python
 mle = freqprob.MLE(freqdist, logprob=False)
 vectorized = freqprob.VectorizedScorer(mle)
-elements = ['cat', 'dog', 'bird']
+elements = ["cat", "dog", "bird"]
 scores = vectorized.score_batch(elements)
 # Returns numpy array of scores
 ```
@@ -786,12 +783,9 @@ def score_batch(self, elements: List[Element]) -> Dict[str, np.ndarray]
 
 **Example:**
 ```python
-scorers = {
-    'mle': freqprob.MLE(freqdist),
-    'laplace': freqprob.Laplace(freqdist)
-}
+scorers = {"mle": freqprob.MLE(freqdist), "laplace": freqprob.Laplace(freqdist)}
 batch_scorer = freqprob.BatchScorer(scorers)
-results = batch_scorer.score_batch(['cat', 'dog'])
+results = batch_scorer.score_batch(["cat", "dog"])
 # Returns: {'mle': array([...]), 'laplace': array([...])}
 ```
 
@@ -822,8 +816,8 @@ def create_lazy_laplace(freqdist: FrequencyDistribution,
 ```python
 lazy_mle = freqprob.create_lazy_mle(huge_freqdist)
 # Only computes probabilities when accessed
-prob = lazy_mle('word')  # Computed on first access
-prob = lazy_mle('word')  # Cached on subsequent access
+prob = lazy_mle("word")  # Computed on first access
+prob = lazy_mle("word")  # Cached on subsequent access
 ```
 
 ### LazyScoringMethod
@@ -893,11 +887,8 @@ def create_compressed_distribution(
 
 **Example:**
 ```python
-large_freqdist = {f'word_{i}': max(1, 1000-i) for i in range(10000)}
-compressed = freqprob.create_compressed_distribution(
-    large_freqdist,
-    quantization_levels=1024
-)
+large_freqdist = {f"word_{i}": max(1, 1000 - i) for i in range(10000)}
+compressed = freqprob.create_compressed_distribution(large_freqdist, quantization_levels=1024)
 print(compressed.get_memory_usage())
 ```
 
@@ -1068,9 +1059,9 @@ def load_state(cls, filepath: str) -> 'StreamingMLE'
 **Example:**
 ```python
 streaming_mle = freqprob.StreamingMLE(max_vocabulary_size=10000, logprob=False)
-streaming_mle.update_single('word1', 5)
-streaming_mle.update_batch(['word2', 'word3'])
-prob = streaming_mle('word1')
+streaming_mle.update_single("word1", 5)
+streaming_mle.update_batch(["word2", "word3"])
+prob = streaming_mle("word1")
 ```
 
 ---
@@ -1165,8 +1156,7 @@ class IncrementalScoringMethod(ABC):
     def update_single(self, element: Element, count: int = 1) -> None: ...
 
     @abstractmethod
-    def update_batch(self, elements: List[Element],
-                     counts: Optional[List[int]] = None) -> None: ...
+    def update_batch(self, elements: List[Element], counts: Optional[List[int]] = None) -> None: ...
 
     @abstractmethod
     def get_update_count(self) -> int: ...
@@ -1212,7 +1202,7 @@ except RuntimeError:
 import freqprob
 
 # Create frequency distribution
-freqdist = {'the': 100, 'cat': 50, 'dog': 30, 'bird': 10}
+freqdist = {"the": 100, "cat": 50, "dog": 30, "bird": 10}
 
 # Basic smoothing
 mle = freqprob.MLE(freqdist, logprob=False)
@@ -1227,17 +1217,17 @@ print(f"Laplace P(unseen) = {laplace('elephant'):.6f}")
 
 ```python
 # N-gram language modeling
-bigrams = {('the', 'cat'): 5, ('the', 'dog'): 3, ('a', 'cat'): 2}
+bigrams = {("the", "cat"): 5, ("the", "dog"): 3, ("a", "cat"): 2}
 kn = freqprob.KneserNey(bigrams, discount=0.75, logprob=True)
 
 # Model evaluation
-test_bigrams = [('the', 'cat'), ('a', 'dog')]
+test_bigrams = [("the", "cat"), ("a", "dog")]
 pp = freqprob.perplexity(kn, test_bigrams)
 print(f"Perplexity: {pp:.2f}")
 
 # Efficiency features
 vectorized = freqprob.VectorizedScorer(laplace)
-batch_scores = vectorized.score_batch(['cat', 'dog', 'bird'])
+batch_scores = vectorized.score_batch(["cat", "dog", "bird"])
 ```
 
 ### Streaming Usage
@@ -1253,7 +1243,7 @@ for word in data_stream:
         print(f"Processed {streaming.get_update_count()} updates")
 
 # Get current probability
-current_prob = streaming('word')
+current_prob = streaming("word")
 ```
 
 This API reference provides comprehensive documentation for all FreqProb functionality. For additional examples and tutorials, see the user guide and Jupyter notebooks.

--- a/docs/LLM_DOCUMENTATION.md
+++ b/docs/LLM_DOCUMENTATION.md
@@ -42,8 +42,8 @@ word_counts = Counter(text.split())
 model = freqprob.Laplace(word_counts, bins=1000, logprob=False)
 
 # Get probabilities for words
-prob_the = model("the")      # High probability (frequent word)
-prob_dog = model("dog")      # Low probability (unseen word)
+prob_the = model("the")  # High probability (frequent word)
+prob_dog = model("dog")  # Low probability (unseen word)
 
 # Use log-probabilities for numerical stability
 log_model = freqprob.Laplace(word_counts, bins=1000, logprob=True)
@@ -99,10 +99,10 @@ All smoothing methods share these parameters:
 
 ```python
 model = freqprob.SomeMethod(
-    freqdist,           # Required: frequency distribution (dict-like)
-    unobs_prob=0.01,    # Optional: probability mass for unseen elements
-    logprob=True,       # Optional: return log-probabilities (default: True)
-    bins=10000,         # Optional: total vocabulary size (method-specific)
+    freqdist,  # Required: frequency distribution (dict-like)
+    unobs_prob=0.01,  # Optional: probability mass for unseen elements
+    logprob=True,  # Optional: return log-probabilities (default: True)
+    bins=10000,  # Optional: total vocabulary size (method-specific)
 )
 ```
 
@@ -132,8 +132,8 @@ counts = {"apple": 10, "banana": 5, "orange": 3}
 
 # Basic MLE
 mle = freqprob.MLE(counts, logprob=False)
-print(mle("apple"))    # 10/18 = 0.556
-print(mle("grape"))    # 0.0 (unseen word)
+print(mle("apple"))  # 10/18 = 0.556
+print(mle("grape"))  # 0.0 (unseen word)
 
 # MLE with reserved mass for unseen words
 mle_smooth = freqprob.MLE(counts, unobs_prob=0.1, logprob=False)
@@ -159,8 +159,8 @@ vocab_size = 10000  # Estimated total vocabulary
 laplace = freqprob.Laplace(counts, bins=vocab_size, logprob=False)
 
 # All words get non-zero probability
-print(laplace("the"))        # (100+1) / (170+10000)
-print(laplace("unseen"))     # 1 / (170+10000)
+print(laplace("the"))  # (100+1) / (170+10000)
+print(laplace("unseen"))  # 1 / (170+10000)
 ```
 
 ### 3. Lidstone Smoothing (Add-k)
@@ -224,7 +224,7 @@ weak_prior = freqprob.Bayesian(counts, alpha=0.5, logprob=False)
 strong_prior = freqprob.Bayesian(counts, alpha=10.0, logprob=False)
 
 # Strong prior pulls probabilities toward uniform
-print(weak_prior("positive"))    # Closer to MLE
+print(weak_prior("positive"))  # Closer to MLE
 print(strong_prior("positive"))  # Closer to 1/3
 ```
 
@@ -243,15 +243,15 @@ print(strong_prior("positive"))  # Closer to 1/3
 import freqprob
 
 # Good-Turing works best with large, diverse datasets
-large_counts = {f"word_{i}": max(1, 1000 - i*2) for i in range(500)}
+large_counts = {f"word_{i}": max(1, 1000 - i * 2) for i in range(500)}
 
 try:
     # Default: bins = V_observed + N1 (singletons)
     sgt = freqprob.SimpleGoodTuring(large_counts, logprob=True)
 
     # Good-Turing excels at low-frequency and unseen words
-    prob_rare = sgt("word_400")      # Rare word
-    prob_unseen = sgt("new_word")    # Per-word unseen probability
+    prob_rare = sgt("word_400")  # Rare word
+    prob_unseen = sgt("new_word")  # Per-word unseen probability
 
     # Access total unseen mass (p0) if needed
     total_mass = sgt.total_unseen_mass  # Total for ALL unseen words
@@ -260,7 +260,7 @@ try:
     sgt_large = freqprob.SimpleGoodTuring(
         large_counts,
         bins=10000,  # Estimated total vocabulary
-        logprob=True
+        logprob=True,
     )
 
 except ValueError as e:
@@ -321,7 +321,7 @@ laplace_model = freqprob.Laplace(counts, bins=5000, logprob=True)
 interpolated = freqprob.Interpolated(
     [mle_model, laplace_model],
     weights=[0.7, 0.3],  # 70% MLE, 30% Laplace
-    logprob=True
+    logprob=True,
 )
 
 prob = interpolated("word")
@@ -380,9 +380,8 @@ for label in ["positive", "negative"]:
     word_counts = Counter(class_words)
     vocab_size = len(all_words)
 
-    class_models[label] = freqprob.Laplace(
-        word_counts, bins=vocab_size, logprob=True
-    )
+    class_models[label] = freqprob.Laplace(word_counts, bins=vocab_size, logprob=True)
+
 
 # Classify new text
 def classify(text):
@@ -397,6 +396,7 @@ def classify(text):
     # Return highest scoring class
     return max(scores.items(), key=lambda x: x[1])[0]
 
+
 # Test
 result = classify("great wonderful movie")
 print(f"Predicted class: {result}")  # "positive"
@@ -407,10 +407,12 @@ print(f"Predicted class: {result}")  # "positive"
 ```python
 import freqprob
 
+
 # Generate bigrams from text
 def generate_bigrams(text):
     words = text.split()
     return list(zip(words[:-1], words[1:]))
+
 
 # Training
 corpus = [
@@ -428,11 +430,13 @@ bigram_counts = Counter(all_bigrams)
 # Build Kneser-Ney model
 lm = freqprob.KneserNey(bigram_counts, discount=0.75, logprob=True)
 
+
 # Compute sentence probability
 def sentence_probability(sentence, model):
     bigrams = generate_bigrams(sentence)
     log_prob = sum(model(bg) for bg in bigrams)
     return log_prob
+
 
 # Evaluate
 test_sentence = "the cat sat"
@@ -454,8 +458,16 @@ from collections import Counter
 
 # User interaction history
 user_clicks = [
-    "electronics", "phone", "laptop", "phone", "tablet",
-    "electronics", "laptop", "laptop", "headphones", "phone"
+    "electronics",
+    "phone",
+    "laptop",
+    "phone",
+    "tablet",
+    "electronics",
+    "laptop",
+    "laptop",
+    "headphones",
+    "phone",
 ]
 
 # Build frequency distribution
@@ -466,11 +478,7 @@ model = freqprob.ELE(click_counts, bins=100, logprob=False)
 
 # Rank categories by probability
 categories = ["phone", "laptop", "tablet", "camera", "speaker"]
-ranked = sorted(
-    categories,
-    key=lambda cat: model(cat),
-    reverse=True
-)
+ranked = sorted(categories, key=lambda cat: model(cat), reverse=True)
 
 print("Recommended categories:", ranked)
 # Output: ['phone', 'laptop', 'tablet', 'speaker', 'camera']
@@ -528,7 +536,7 @@ initial_counts = {"word1": 10, "word2": 5}
 streaming_model = freqprob.StreamingMLE(
     initial_data=initial_counts,
     max_vocabulary_size=10000,  # Limit memory usage
-    logprob=True
+    logprob=True,
 )
 
 # Update incrementally as new data arrives
@@ -552,7 +560,7 @@ huge_counts = {f"word_{i}": i for i in range(100000)}
 # Compress to reduce memory (quantizes counts)
 compressed = freqprob.create_compressed_distribution(
     huge_counts,
-    quantization_levels=256  # 8-bit quantization
+    quantization_levels=256,  # 8-bit quantization
 )
 
 # Use compressed distribution
@@ -674,11 +682,7 @@ import freqprob
 # Profile memory usage during model creation
 profiler = freqprob.MemoryProfiler()
 
-metrics = profiler.profile_method_creation(
-    freqprob.SimpleGoodTuring,
-    large_counts,
-    iterations=5
-)
+metrics = profiler.profile_method_creation(freqprob.SimpleGoodTuring, large_counts, iterations=5)
 
 print(f"Peak memory: {metrics.peak_memory_mb:.1f} MB")
 print(f"Average time: {metrics.avg_time:.3f} seconds")
@@ -702,23 +706,19 @@ Requires `pip install freqprob[validation]`:
 import freqprob
 
 # Quick validation check
-is_valid = freqprob.quick_validate_method(
-    freqprob.Laplace,
-    test_distribution
-)
+is_valid = freqprob.quick_validate_method(freqprob.Laplace, test_distribution)
 
 # Comprehensive validation
 validator = freqprob.ValidationSuite()
 result = validator.validate_method(
-    freqprob.ELE,
-    test_distributions=[small_dist, medium_dist, large_dist]
+    freqprob.ELE, test_distributions=[small_dist, medium_dist, large_dist]
 )
 
 # Performance comparison
 comparison = freqprob.compare_method_performance(
     methods=[freqprob.MLE, freqprob.Laplace, freqprob.KneserNey],
     distributions=[test_dist],
-    test_data=validation_data
+    test_data=validation_data,
 )
 ```
 
@@ -744,6 +744,7 @@ trigrams = freqprob.generate_ngrams(tokens, n=3)
 
 # Count n-gram frequencies
 from collections import Counter
+
 bigram_counts = Counter(bigrams)
 ```
 
@@ -773,6 +774,7 @@ ngram_freq = freqprob.ngram_frequency(ngrams, n=1)
 import freqprob
 from collections import Counter
 
+
 def select_best_model(train_data, validation_data, vocab_size):
     """Select best smoothing method via validation perplexity."""
 
@@ -796,6 +798,7 @@ def select_best_model(train_data, validation_data, vocab_size):
     best_name = min(results.items(), key=lambda x: x[1])[0]
     return models[best_name], results
 
+
 # Usage
 train = ["word1", "word2", "word1"] * 100
 validation = ["word1", "word3", "word2"] * 20
@@ -808,6 +811,7 @@ print(f"Best model perplexity: {min(scores.values()):.2f}")
 
 ```python
 import freqprob
+
 
 # Use different smoothing for different frequency ranges
 def hierarchical_smoothing(counts, vocab_size):
@@ -838,6 +842,7 @@ def hierarchical_smoothing(counts, vocab_size):
 ```python
 import freqprob
 
+
 def adapt_model(general_counts, domain_counts, domain_weight=0.7):
     """Interpolate general and domain-specific models."""
 
@@ -847,12 +852,11 @@ def adapt_model(general_counts, domain_counts, domain_weight=0.7):
 
     # Interpolate with domain preference
     adapted = freqprob.Interpolated(
-        [domain_model, general_model],
-        weights=[domain_weight, 1 - domain_weight],
-        logprob=True
+        [domain_model, general_model], weights=[domain_weight, 1 - domain_weight], logprob=True
     )
 
     return adapted
+
 
 # Usage
 general_text = ["common", "word", "the"] * 1000
@@ -940,6 +944,7 @@ log_product = log_p1 + log_p2  # log(P1 × P2)
 
 # Convert back to probability if needed
 import math
+
 probability = math.exp(log_product)
 ```
 
@@ -984,9 +989,7 @@ simple_model = freqprob.Laplace(counts, bins=5000, logprob=True)
 
 # Profile if performance is an issue
 profiler = freqprob.MemoryProfiler()
-metrics = profiler.profile_method_creation(
-    freqprob.Laplace, counts, iterations=10
-)
+metrics = profiler.profile_method_creation(freqprob.Laplace, counts, iterations=10)
 
 # Only optimize if needed
 if metrics.avg_time > 1.0:  # > 1 second
@@ -1024,6 +1027,7 @@ log_power = log_p1 * n
 
 # Sum of probabilities (use logsumexp for stability)
 from scipy.special import logsumexp
+
 log_probs = [model(w) for w in words]
 log_sum = logsumexp(log_probs)
 ```
@@ -1043,25 +1047,37 @@ log_sum = logsumexp(log_probs)
 ```python
 # Main classes
 from freqprob import (
-    MLE, Laplace, Lidstone, ELE,
-    Bayesian, SimpleGoodTuring,
-    KneserNey, ModifiedKneserNey,
-    WittenBell, CertaintyDegree,
+    MLE,
+    Laplace,
+    Lidstone,
+    ELE,
+    Bayesian,
+    SimpleGoodTuring,
+    KneserNey,
+    ModifiedKneserNey,
+    WittenBell,
+    CertaintyDegree,
     Interpolated,
 )
 
 # Utilities
 from freqprob import (
-    perplexity, cross_entropy, kl_divergence,
+    perplexity,
+    cross_entropy,
+    kl_divergence,
     model_comparison,
-    generate_ngrams, ngram_frequency, word_frequency,
+    generate_ngrams,
+    ngram_frequency,
+    word_frequency,
 )
 
 # Performance
 from freqprob import (
-    VectorizedScorer, BatchScorer,
+    VectorizedScorer,
+    BatchScorer,
     create_vectorized_batch_scorer,
-    StreamingMLE, StreamingLaplace,
+    StreamingMLE,
+    StreamingLaplace,
     LazyBatchScorer,
 )
 
@@ -1073,12 +1089,14 @@ from freqprob import (
 
 # Caching
 from freqprob import (
-    get_cache_stats, clear_all_caches,
+    get_cache_stats,
+    clear_all_caches,
 )
 
 # Profiling (optional)
 from freqprob import (
-    MemoryMonitor, MemoryProfiler,
+    MemoryMonitor,
+    MemoryProfiler,
     DistributionMemoryAnalyzer,
 )
 
@@ -1098,6 +1116,7 @@ from freqprob import (
 import freqprob
 from collections import Counter
 from typing import List, Tuple
+
 
 class TextCategorizer:
     """Multi-class text categorization using smoothed language models."""
@@ -1134,17 +1153,11 @@ class TextCategorizer:
             counts = Counter(words)
 
             if self.smoothing == "laplace":
-                model = freqprob.Laplace(
-                    counts, bins=self.vocab_size, logprob=True
-                )
+                model = freqprob.Laplace(counts, bins=self.vocab_size, logprob=True)
             elif self.smoothing == "ele":
-                model = freqprob.ELE(
-                    counts, bins=self.vocab_size, logprob=True
-                )
+                model = freqprob.ELE(counts, bins=self.vocab_size, logprob=True)
             elif self.smoothing == "bayesian":
-                model = freqprob.Bayesian(
-                    counts, alpha=1.0, logprob=True
-                )
+                model = freqprob.Bayesian(counts, alpha=1.0, logprob=True)
             else:
                 raise ValueError(f"Unknown smoothing: {self.smoothing}")
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -40,7 +40,7 @@ pip install freqprob
 import freqprob
 
 # Create a frequency distribution
-freqdist = {'the': 1000, 'cat': 50, 'dog': 30, 'bird': 10}
+freqdist = {"the": 1000, "cat": 50, "dog": 30, "bird": 10}
 
 # Basic Maximum Likelihood Estimation
 mle = freqprob.MLE(freqdist, logprob=False)
@@ -51,8 +51,8 @@ laplace = freqprob.Laplace(freqdist, logprob=False)
 print(f"P(unknown) = {laplace('unknown')}")  # Non-zero probability
 
 # Model Comparison
-models = {'mle': mle, 'laplace': laplace}
-test_data = ['the', 'cat', 'unknown']
+models = {"mle": mle, "laplace": laplace}
+test_data = ["the", "cat", "unknown"]
 comparison = freqprob.model_comparison(models, test_data)
 print(comparison)
 ```
@@ -104,7 +104,7 @@ $$P_{MLE}(w) = \frac{c(w)}{N}$$
 **Implementation:**
 ```python
 mle = freqprob.MLE(freqdist, logprob=False)
-prob = mle('word')
+prob = mle("word")
 ```
 
 ### Uniform Distribution
@@ -231,8 +231,8 @@ where `bins` is the estimated total vocabulary size (default: $V + N_1$).
 ```python
 # Basic usage with automatic bins estimation
 sgt = freqprob.SimpleGoodTuring(freqdist, logprob=False)
-print(sgt('word'))              # Per-word probability
-print(sgt.total_unseen_mass)    # Access p₀
+print(sgt("word"))  # Per-word probability
+print(sgt.total_unseen_mass)  # Access p₀
 
 # Custom vocabulary size
 sgt_large = freqprob.SimpleGoodTuring(freqdist, bins=10000, logprob=False)
@@ -290,11 +290,15 @@ where:
 ```python
 # Input should be bigrams: {(context, word): count}
 bigram_counts = {
-    ('the', 'cat'): 5, ('the', 'dog'): 3, ('a', 'cat'): 2,
-    ('a', 'dog'): 1, ('big', 'cat'): 1, ('small', 'dog'): 1
+    ("the", "cat"): 5,
+    ("the", "dog"): 3,
+    ("a", "cat"): 2,
+    ("a", "dog"): 1,
+    ("big", "cat"): 1,
+    ("small", "dog"): 1,
 }
 kn = freqprob.KneserNey(bigram_counts, discount=0.75, logprob=False)
-prob = kn(('the', 'cat'))
+prob = kn(("the", "cat"))
 ```
 
 ### Modified Kneser-Ney Smoothing
@@ -353,25 +357,21 @@ $$P_{interp}(w) = \lambda P_{high}(w) + (1-\lambda) P_{low}(w)$$
 **Implementation:**
 ```python
 # N-gram interpolation (automatic mode detection)
-trigrams = {('the', 'big', 'cat'): 3, ('a', 'big', 'dog'): 2}
-bigrams = {('big', 'cat'): 5, ('big', 'dog'): 3, ('small', 'cat'): 2}
+trigrams = {("the", "big", "cat"): 3, ("a", "big", "dog"): 2}
+bigrams = {("big", "cat"): 5, ("big", "dog"): 3, ("small", "cat"): 2}
 
-interpolated = freqprob.Interpolated(
-    trigrams, bigrams, lambda_weight=0.7, logprob=False
-)
+interpolated = freqprob.Interpolated(trigrams, bigrams, lambda_weight=0.7, logprob=False)
 
 # Observed trigram: 0.7 * (3/5) + 0.3 * (5/10) = 0.57
-print(interpolated(('the', 'big', 'cat')))
+print(interpolated(("the", "big", "cat")))
 
 # Unseen trigram with observed context: 0.7 * 0 + 0.3 * (5/10) = 0.15
-print(interpolated(('unseen', 'big', 'cat')))
+print(interpolated(("unseen", "big", "cat")))
 
 # Same-type interpolation (strings)
-high_freq = {'cat': 10, 'dog': 5}
-low_freq = {'cat': 3, 'dog': 2, 'bird': 1}
-interp_str = freqprob.Interpolated(
-    high_freq, low_freq, lambda_weight=0.8, logprob=False
-)
+high_freq = {"cat": 10, "dog": 5}
+low_freq = {"cat": 3, "dog": 2, "bird": 1}
+interp_str = freqprob.Interpolated(high_freq, low_freq, lambda_weight=0.8, logprob=False)
 ```
 
 **Properties:**
@@ -412,11 +412,11 @@ scorer = freqprob.MLE(large_freqdist, logprob=False)
 vectorized = VectorizedScorer(scorer)
 
 # Score batch of elements efficiently
-elements = ['word1', 'word2', 'word3', ...]
+elements = ["word1", "word2", "word3", ...]
 scores = vectorized.score_batch(elements)  # Returns numpy array
 
 # Matrix operations
-elements_2d = [['word1', 'word2'], ['word3', 'word4']]
+elements_2d = [["word1", "word2"], ["word3", "word4"]]
 score_matrix = vectorized.score_matrix(elements_2d)
 
 # Top-k most probable elements
@@ -428,9 +428,9 @@ top_elements, top_scores = vectorized.top_k_elements(10)
 from freqprob import BatchScorer
 
 scorers = {
-    'mle': freqprob.MLE(freqdist),
-    'laplace': freqprob.Laplace(freqdist),
-    'kneser_ney': freqprob.KneserNey(bigram_freqdist)
+    "mle": freqprob.MLE(freqdist),
+    "laplace": freqprob.Laplace(freqdist),
+    "kneser_ney": freqprob.KneserNey(bigram_freqdist),
 }
 
 batch_scorer = BatchScorer(scorers)
@@ -466,10 +466,10 @@ from freqprob import create_lazy_mle
 lazy_scorer = create_lazy_mle(huge_freqdist, logprob=False)
 
 # First access triggers computation
-prob1 = lazy_scorer('frequent_word')  # Computed
+prob1 = lazy_scorer("frequent_word")  # Computed
 
 # Subsequent accesses use cached value
-prob2 = lazy_scorer('frequent_word')  # Cached
+prob2 = lazy_scorer("frequent_word")  # Cached
 
 # Check what's been computed
 computed = lazy_scorer.get_computed_elements()
@@ -490,7 +490,7 @@ from freqprob import StreamingFrequencyDistribution
 stream_dist = StreamingFrequencyDistribution(
     max_vocabulary_size=10000,
     min_count_threshold=2,
-    decay_factor=0.99  # Exponential forgetting
+    decay_factor=0.99,  # Exponential forgetting
 )
 
 # Process streaming data
@@ -509,15 +509,15 @@ from freqprob import StreamingMLE
 streaming_mle = StreamingMLE(max_vocabulary_size=10000, logprob=False)
 
 # Update with new observations
-streaming_mle.update_single('word', 5)
-streaming_mle.update_batch(['word1', 'word2', 'word1'])
+streaming_mle.update_single("word", 5)
+streaming_mle.update_batch(["word1", "word2", "word1"])
 
 # Get current probabilities
-prob = streaming_mle('word')
+prob = streaming_mle("word")
 
 # Save/load state
-streaming_mle.save_state('model.pkl')
-loaded_model = StreamingMLE.load_state('model.pkl')
+streaming_mle.save_state("model.pkl")
+loaded_model = StreamingMLE.load_state("model.pkl")
 ```
 
 ### Memory-Efficient Representations
@@ -529,13 +529,13 @@ For large vocabularies, use compressed representations to reduce memory usage.
 from freqprob import create_compressed_distribution
 
 # 50-90% memory savings
-large_freqdist = {f'word_{i}': max(1, 10000-i) for i in range(100000)}
+large_freqdist = {f"word_{i}": max(1, 10000 - i) for i in range(100000)}
 
 # With quantization for additional compression
 compressed = create_compressed_distribution(
     large_freqdist,
     quantization_levels=1024,  # Trade-off: memory vs precision
-    use_compression=True
+    use_compression=True,
 )
 
 # Check memory usage
@@ -548,7 +548,7 @@ print(f"Total memory: {memory_info['total'] / 1024 / 1024:.2f} MB")
 from freqprob import create_sparse_distribution
 
 # Optimized for distributions with many zeros
-sparse_freqdist = {'rare_word': 1, 'common_word': 10000}
+sparse_freqdist = {"rare_word": 1, "common_word": 10000}
 sparse = create_sparse_distribution(sparse_freqdist)
 
 # Efficient queries
@@ -585,7 +585,7 @@ FreqProb provides standard evaluation metrics for comparing different smoothing 
 from freqprob import perplexity
 
 model = freqprob.KneserNey(train_bigrams, logprob=True)
-test_data = [('the', 'cat'), ('a', 'dog'), ('big', 'house')]
+test_data = [("the", "cat"), ("a", "dog"), ("big", "house")]
 
 pp = perplexity(model, test_data)
 print(f"Perplexity: {pp:.2f}")  # Lower is better
@@ -604,15 +604,14 @@ print(f"Cross-entropy: {ce:.2f} bits")  # Lower is better
 from freqprob import model_comparison
 
 models = {
-    'mle': freqprob.MLE(train_data, logprob=True),
-    'laplace': freqprob.Laplace(train_data, logprob=True),
-    'kneser_ney': freqprob.KneserNey(train_bigrams, logprob=True)
+    "mle": freqprob.MLE(train_data, logprob=True),
+    "laplace": freqprob.Laplace(train_data, logprob=True),
+    "kneser_ney": freqprob.KneserNey(train_bigrams, logprob=True),
 }
 
 comparison = model_comparison(models, test_data)
 for model_name, metrics in comparison.items():
-    print(f"{model_name}: PP={metrics['perplexity']:.2f}, "
-          f"CE={metrics['cross_entropy']:.2f}")
+    print(f"{model_name}: PP={metrics['perplexity']:.2f}, CE={metrics['cross_entropy']:.2f}")
 ```
 
 **KL Divergence:**
@@ -633,12 +632,13 @@ def evaluate_smoothing_method(method_class, train_data, test_data, **kwargs):
     model = method_class(train_data, logprob=True, **kwargs)
 
     metrics = {
-        'perplexity': perplexity(model, test_data),
-        'cross_entropy': cross_entropy(model, test_data),
-        'coverage': sum(1 for item in test_data if model(item) > -20) / len(test_data)
+        "perplexity": perplexity(model, test_data),
+        "cross_entropy": cross_entropy(model, test_data),
+        "coverage": sum(1 for item in test_data if model(item) > -20) / len(test_data),
     }
 
     return metrics
+
 
 # Compare different gamma values for Lidstone
 gammas = [0.01, 0.1, 0.5, 1.0, 2.0]
@@ -650,7 +650,7 @@ for gamma in gammas:
     )
 
 # Find best gamma
-best_gamma = min(results.keys(), key=lambda g: results[g]['perplexity'])
+best_gamma = min(results.keys(), key=lambda g: results[g]["perplexity"])
 print(f"Best gamma: {best_gamma} (PP: {results[best_gamma]['perplexity']:.2f})")
 ```
 
@@ -680,12 +680,13 @@ print(f"Best gamma: {best_gamma} (PP: {results[best_gamma]['perplexity']:.2f})")
 from sklearn.model_selection import ParameterGrid
 import numpy as np
 
+
 def tune_lidstone_gamma(train_data, val_data):
     """Find optimal gamma for Lidstone smoothing."""
-    param_grid = {'gamma': np.logspace(-3, 1, 20)}  # 0.001 to 10
+    param_grid = {"gamma": np.logspace(-3, 1, 20)}  # 0.001 to 10
 
     best_gamma = None
-    best_perplexity = float('inf')
+    best_perplexity = float("inf")
 
     for params in ParameterGrid(param_grid):
         model = freqprob.Lidstone(train_data, logprob=True, **params)
@@ -693,9 +694,10 @@ def tune_lidstone_gamma(train_data, val_data):
 
         if pp < best_perplexity:
             best_perplexity = pp
-            best_gamma = params['gamma']
+            best_gamma = params["gamma"]
 
     return best_gamma, best_perplexity
+
 
 gamma, pp = tune_lidstone_gamma(train_freqdist, val_data)
 print(f"Optimal gamma: {gamma:.4f} (Perplexity: {pp:.2f})")
@@ -709,11 +711,12 @@ print(f"Optimal gamma: {gamma:.4f} (Perplexity: {pp:.2f})")
 compressed_dist = create_compressed_distribution(
     large_freqdist,
     quantization_levels=2048,  # Balance memory vs accuracy
-    use_compression=True
+    use_compression=True,
 )
 
 # Monitor memory usage
 from freqprob import MemoryProfiler
+
 profiler = MemoryProfiler()
 
 with profiler.profile_operation("model_training"):
@@ -727,13 +730,13 @@ print(f"Memory usage: {profiler.get_latest_metrics().memory_delta_mb:.2f} MB")
 # Configure streaming with appropriate limits
 streaming_model = freqprob.StreamingMLE(
     max_vocabulary_size=50000,  # Limit vocabulary
-    logprob=True
+    logprob=True,
 )
 
 # Process data in batches for efficiency
 batch_size = 1000
 for i in range(0, len(data_stream), batch_size):
-    batch = data_stream[i:i+batch_size]
+    batch = data_stream[i : i + batch_size]
     streaming_model.update_batch(batch)
 ```
 
@@ -755,7 +758,7 @@ scores = vectorized.score_batch(large_list)  # Fast
 lazy_model = create_lazy_mle(huge_freqdist)
 
 # Only compute what you need
-important_words = ['the', 'of', 'and', 'to', 'a']
+important_words = ["the", "of", "and", "to", "a"]
 important_probs = [lazy_model(word) for word in important_words]
 
 # Check computation efficiency
@@ -778,7 +781,7 @@ def build_ngram_model(text_corpus, n=3):
     for sentence in text_corpus:
         tokens = sentence.split()
         # Add sentence boundaries
-        padded = ['<s>'] * (n-1) + tokens + ['</s>']
+        padded = ["<s>"] * (n - 1) + tokens + ["</s>"]
         ngrams.extend(generate_ngrams(padded, n))
 
     # Create frequency distribution
@@ -789,18 +792,21 @@ def build_ngram_model(text_corpus, n=3):
 
     return model
 
+
 # Usage
 corpus = ["the cat sat on the mat", "a dog ran in the park"]
 model = build_ngram_model(corpus, n=3)
 
+
 # Calculate sentence probability
 def sentence_probability(model, sentence, n=3):
     tokens = sentence.split()
-    padded = ['<s>'] * (n-1) + tokens + ['</s>']
+    padded = ["<s>"] * (n - 1) + tokens + ["</s>"]
     ngrams = generate_ngrams(padded, n)
 
     log_prob = sum(model(ngram) for ngram in ngrams)
     return math.exp(log_prob)
+
 
 prob = sentence_probability(model, "the cat ran")
 print(f"P(sentence) = {prob:.2e}")
@@ -837,12 +843,9 @@ def extract_smoothed_features(documents, smoothing_method=freqprob.Laplace):
 
     return features, sorted(vocab)
 
+
 # Usage
-docs = [
-    "the cat is happy",
-    "the dog is sad",
-    "cats and dogs are pets"
-]
+docs = ["the cat is happy", "the dog is sad", "cats and dogs are pets"]
 
 features, vocabulary = extract_smoothed_features(docs)
 print(f"Vocabulary size: {len(vocabulary)}")
@@ -865,11 +868,11 @@ def build_document_language_model(document, background_model, lambda_mix=0.8):
 
     # Interpolate with background model
     interpolated = Interpolated(
-        doc_freqdist, background_model._freqdist,
-        lambda_weight=lambda_mix, logprob=True
+        doc_freqdist, background_model._freqdist, lambda_weight=lambda_mix, logprob=True
     )
 
     return interpolated
+
 
 def score_query(query, doc_models):
     """Score a query against document models."""
@@ -883,11 +886,12 @@ def score_query(query, doc_models):
 
     return scores
 
+
 # Usage
 documents = [
     "machine learning algorithms for classification",
     "natural language processing with neural networks",
-    "computer vision and image recognition"
+    "computer vision and image recognition",
 ]
 
 # Build background model from all documents
@@ -908,7 +912,7 @@ scores = score_query(query, doc_models)
 # Rank documents
 ranked_docs = sorted(enumerate(scores), key=lambda x: x[1], reverse=True)
 for rank, (doc_idx, score) in enumerate(ranked_docs, 1):
-    print(f"Rank {rank}: Document {doc_idx+1} (score: {score:.2f})")
+    print(f"Rank {rank}: Document {doc_idx + 1} (score: {score:.2f})")
 ```
 
 ### Real-time Text Processing
@@ -925,8 +929,7 @@ class StreamingTopicDetector:
         # Initialize streaming models for each topic
         for topic in topics:
             self.topic_models[topic] = freqprob.StreamingMLE(
-                max_vocabulary_size=max_vocab_size,
-                logprob=True
+                max_vocabulary_size=max_vocab_size, logprob=True
             )
 
     def update_topic(self, topic, text):
@@ -955,14 +958,15 @@ class StreamingTopicDetector:
             stats[topic] = model.get_streaming_statistics()
         return stats
 
+
 # Usage
-detector = StreamingTopicDetector(['sports', 'technology', 'politics'])
+detector = StreamingTopicDetector(["sports", "technology", "politics"])
 
 # Train with streaming data
 training_data = [
-    ('sports', 'football soccer basketball game score'),
-    ('technology', 'computer software algorithm programming'),
-    ('politics', 'government election policy vote democracy')
+    ("sports", "football soccer basketball game score"),
+    ("technology", "computer software algorithm programming"),
+    ("politics", "government election policy vote democracy"),
 ]
 
 for topic, text in training_data:
@@ -983,7 +987,7 @@ FreqProb provides several memory optimization techniques for large-scale applica
 **Compressed Storage:**
 ```python
 # Compressed storage for large vocabularies
-large_dist = {f'word_{i}': count for i, count in enumerate(counts)}
+large_dist = {f"word_{i}": count for i, count in enumerate(counts)}
 compressed = freqprob.create_compressed_distribution(large_dist)
 
 # Significant memory reduction with minimal accuracy loss
@@ -1024,21 +1028,17 @@ Validate implementation correctness and performance:
 
 ```python
 # Validate implementation correctness
-is_valid = freqprob.quick_validate_method(
-    freqprob.Laplace, test_distribution, bins=1000
-)
+is_valid = freqprob.quick_validate_method(freqprob.Laplace, test_distribution, bins=1000)
 
 # Comprehensive validation suite
 validator = freqprob.ValidationSuite()
 results = validator.run_comprehensive_validation(
     method_classes=[freqprob.MLE, freqprob.Laplace, freqprob.ELE],
-    test_distributions=[test_dist1, test_dist2]
+    test_distributions=[test_dist1, test_dist2],
 )
 
 # Performance benchmarking
-performance_metrics = freqprob.profile_method_performance(
-    freqprob.KneserNey, test_distribution
-)
+performance_metrics = freqprob.profile_method_performance(freqprob.KneserNey, test_distribution)
 print(f"Creation time: {performance_metrics.duration_seconds:.4f}s")
 ```
 
@@ -1048,11 +1048,12 @@ print(f"Creation time: {performance_metrics.duration_seconds:.4f}s")
 ```python
 # Vectorized batch processing
 vectorized = freqprob.VectorizedScorer(laplace)
-words = ['cat', 'dog', 'bird', 'fish'] * 1000
+words = ["cat", "dog", "bird", "fish"] * 1000
 scores = vectorized.score_batch(words)  # Fast batch scoring
 
 # Performance comparison
 import time
+
 start = time.time()
 individual_scores = [laplace(word) for word in words]
 individual_time = time.time() - start
@@ -1063,20 +1064,20 @@ batch_time = time.time() - start
 
 print(f"Individual: {individual_time:.4f}s")
 print(f"Vectorized: {batch_time:.4f}s")
-print(f"Speedup: {individual_time/batch_time:.2f}x")
+print(f"Speedup: {individual_time / batch_time:.2f}x")
 ```
 
 **Model Comparison:**
 ```python
 # Compare multiple models efficiently
 models = {
-    'laplace': freqprob.Laplace(word_counts, bins=10000),
-    'kneser_ney': freqprob.KneserNey(bigrams),
-    'simple_gt': freqprob.SimpleGoodTuring(word_counts)
+    "laplace": freqprob.Laplace(word_counts, bins=10000),
+    "kneser_ney": freqprob.KneserNey(bigrams),
+    "simple_gt": freqprob.SimpleGoodTuring(word_counts),
 }
 
 # Comprehensive model evaluation
-test_data = ['cat', 'dog', 'bird'] * 100
+test_data = ["cat", "dog", "bird"] * 100
 comparison = freqprob.model_comparison(models, test_data)
 
 for model_name, metrics in comparison.items():

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ counts = {"the": 100, "cat": 50, "dog": 30, "bird": 10}
 # Add-one (Laplace) smoothing over a vocabulary of 10,000 possible elements
 laplace = freqprob.Laplace(counts, bins=10_000, logprob=False)
 
-laplace("cat")       # 0.0050  — an observed element
+laplace("cat")  # 0.0050  — an observed element
 laplace("elephant")  # 0.0001  — an unseen element still gets non-zero mass
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ dev = [
     # Code quality (required by Makefile).
     # ruff/mypy pinned exactly so local, CI, and pre-commit run identical linter
     # versions (unpinned ruff/mypy drift silently changes check results).
-    "ruff==0.15.8",
-    "mypy==1.19.1",
+    "ruff==0.16.0",
+    "mypy==2.3.0",
     "bandit[toml]>=1.7.0",
 
     # Bound the stub-bearing scientific deps for the type-check (quality) job,


### PR DESCRIPTION
## Summary

Adopts Dependabot's two dev-tool bumps — **ruff `0.15.8` → `0.16.0`** (#27) and
**mypy `1.19.1` → `2.3.0`** (#28) — but consolidated so they actually land green,
with the pins kept **in lockstep across `pyproject.toml` and
`.pre-commit-config.yaml`** (the repo's stated invariant).

## Why not just merge #27 / #28

- **#27 (ruff) would fail CI as-is.** ruff 0.16.0 changed how it formats embedded
  code blocks in Markdown, so `ruff format --check` fails until the formatter is
  re-run. Dependabot only bumps the version; it doesn't reformat. This PR applies
  `ruff format` to the 8 affected docs (`README`, `CHANGELOG`, `MIGRATION`,
  `ARCHITECTURE`, `docs/*`) — cosmetic comment-spacing in examples only.
- **#28 (mypy) is a major bump** but type-checks cleanly against current `main`:
  `Success: no issues found in 34 source files` (exit 0). Only informational
  "unused config section" notes remain (non-failing).
- Dependabot's pip PRs bump only `pyproject.toml`; `.pre-commit-config.yaml` pins
  the same tools separately and would silently desync. This PR updates both.

## Verification (against current `main`, incl. the new test files)

- `ruff format --check .` — clean
- `ruff check .` — All checks passed
- `mypy` — Success, exit 0
- `pytest` — 315 passed, 5 skipped

No source-code or public API changes.

Closes #27
Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_