### PR TITLE
ci(dependabot): drop references to non-existent labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,9 +14,6 @@ updates:
     commit-message:
       prefix: "deps"
       include: "scope"
-    labels:
-      - "dependencies"
-      - "python"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
@@ -30,6 +27,3 @@ updates:
       - "tresoldi"
     commit-message:
       prefix: "ci"
-    labels:
-      - "dependencies"
-      - "github-actions"


### PR DESCRIPTION
## Summary

Every Dependabot PR posted a warning:

> The following labels could not be found: `dependencies`, `github-actions`. Please create them before Dependabot can add them to a pull request.

`.github/dependabot.yml` referenced labels that don't exist in the repo. This removes the `labels:` directives from both update blocks so the warning stops.

If you'd rather keep auto-labeling, create the labels in the repo (Issues → Labels) and re-add them here.

No workflow or source changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_