### PR TITLE
release: prepare 0.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-07-28
+
+Maintenance release: license/metadata fixes and a full documentation rebuild.
+No library code or public API changes since 0.6.1.
+
 ### Fixed
 
 - **License file corrected to MIT.** The `LICENSE` file contained the full GNU
@@ -31,8 +36,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **All documentation examples are now executed in CI.** New tests run every
   docstring example (`tests/test_doctests.py`) and every Python code block in the
   README and docs (`tests/test_docs_examples.py`), so an example can no longer
-  drift from the code. The README is trimmed to essentials and its citation
-  version corrected to 0.6.1.
+  drift from the code.
+- Bumped pinned dev tooling in lockstep across `pyproject.toml` and
+  `.pre-commit-config.yaml`: **ruff** `0.15.8` → `0.16.0` and **mypy**
+  `1.19.1` → `2.3.0`. Applied ruff 0.16.0's updated formatting (Markdown
+  embedded code blocks).
 
 ### Removed
 
@@ -41,11 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   non-existent APIs), and the four `docs/tutorial_*.py` files. Dropped the
   now-unused `nhandu`/`matplotlib`/`seaborn` dev dependencies and the Makefile
   `docs`/`docs-clean` tutorial targets.
-
-- Bumped pinned dev tooling in lockstep across `pyproject.toml` and
-  `.pre-commit-config.yaml`: **ruff** `0.15.8` → `0.16.0` and **mypy**
-  `1.19.1` → `2.3.0`. Applied ruff 0.16.0's updated formatting (Markdown
-  embedded code blocks). No source-code or public API changes.
 
 ## [0.6.1] - 2026-07-28
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,7 +11,7 @@ authors:
   - family-names: Tresoldi
     given-names: Tiago
     email: freqprob@tresoldi.org
-version: 0.6.1
+version: 0.6.2
 date-released: 2026-07-28
 license: MIT
 repository-code: "https://github.com/tresoldi/freqprob"

--- a/README.md
+++ b/README.md
@@ -97,12 +97,12 @@ compressed/sparse representations.
 If you use FreqProb in academic research, please cite:
 
 ```bibtex
-@software{tresoldi_freqprob_2025,
+@software{tresoldi_freqprob_2026,
   author = {Tresoldi, Tiago},
   title = {FreqProb: A Python library for probability smoothing and frequency-based estimation},
   url = {https://github.com/tresoldi/freqprob},
-  version = {0.6.1},
-  year = {2025}
+  version = {0.6.2},
+  year = {2026}
 }
 ```
 

--- a/src/freqprob/__init__.py
+++ b/src/freqprob/__init__.py
@@ -1,7 +1,7 @@
 """FreqProb: frequency-based probability estimation library."""
 
 # Version of the freqprob package
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 __author__ = "Tiago Tresoldi"
 __email__ = "freqprob@tresoldi.org"
 


### PR DESCRIPTION
## Summary

Prepares the **0.6.2** maintenance release — carrying the license/metadata fixes and the documentation rebuild merged since 0.6.1. **No library code or public API changes.**

## Changes

- **Version** `0.6.1` → `0.6.2` in `src/freqprob/__init__.py` (the single source of truth; `pyproject.toml` reads it dynamically).
- **`CITATION.cff`**: version → `0.6.2`.
- **README BibTeX**: version → `0.6.2`, `year` → `2026`, and the citation **key** `tresoldi_freqprob_2025` → `tresoldi_freqprob_2026`.
- **CHANGELOG**: cut the dated `[0.6.2] - 2026-07-28` section from `[Unreleased]` (and fixed a stray bullet that had landed under the wrong heading).

## Why 0.6.2 matters

The published 0.6.1 on PyPI still carries the old GPL-labeled `LICENSE` and the `uu.se` maintainer email; 0.6.2 is the first release where the corrected MIT license and updated metadata reach PyPI.

## Verification

`python -m build` produces `freqprob-0.6.2.tar.gz` and `freqprob-0.6.2-py3-none-any.whl`; `import freqprob; freqprob.__version__` → `0.6.2`; version consistent across all metadata; ruff format clean.

## Release steps (after merge)

Tag `v0.6.2` on `main` and push it — the tag-triggered `release.yml` builds and publishes to PyPI via trusted publishing. (I'll wait for your go-ahead before tagging, as before.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_