### PR TITLE
docs: add a landing page and serve from freqprob.tresoldi.org

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Documentation landing page.** The docs site now opens with a dedicated,
+  self-contained landing page (a chromeless "monograph" design with a figure
+  illustrating smoothing), served as a MkDocs custom home template; the User
+  Guide and API Reference keep the standard Material navigation behind it.
+- **Custom domain.** The site is served from `https://freqprob.tresoldi.org`
+  (via a `docs/CNAME` file and updated `site_url`); in-repo documentation links
+  were updated accordingly.
+
 ## [0.6.2] - 2026-07-28
 
 Maintenance release: license/metadata fixes and a full documentation rebuild.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/tresoldi/freqprob/actions/workflows/quality.yml/badge.svg)](https://github.com/tresoldi/freqprob/actions/workflows/quality.yml)
 [![codecov](https://codecov.io/gh/tresoldi/freqprob/branch/main/graph/badge.svg)](https://codecov.io/gh/tresoldi/freqprob)
-[![Docs](https://img.shields.io/badge/docs-mkdocs-blue.svg)](https://tresoldi.github.io/freqprob/)
+[![Docs](https://img.shields.io/badge/docs-mkdocs-blue.svg)](https://freqprob.tresoldi.org/)
 [![PyPI version](https://badge.fury.io/py/freqprob.svg)](https://badge.fury.io/py/freqprob)
 [![Python versions](https://img.shields.io/pypi/pyversions/freqprob.svg)](https://pypi.org/project/freqprob/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
@@ -85,11 +85,11 @@ compressed/sparse representations.
 
 ## Documentation
 
-- **[Documentation site](https://tresoldi.github.io/freqprob/)** — user guide and
+- **[Documentation site](https://freqprob.tresoldi.org/)** — user guide and
   full API reference.
 - **[User Guide](docs/USER_GUIDE.md)** — concepts, choosing a method, and worked
   examples across text, ecology, genomics, and categorical data.
-- **[API Reference](https://tresoldi.github.io/freqprob/reference/)** — every
+- **[API Reference](https://freqprob.tresoldi.org/reference/)** — every
   public class and function, generated from the source with a runnable example.
 
 ## Citation

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+freqprob.tresoldi.org

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,48 +1,7 @@
-# FreqProb
-
-**Turn frequency counts into probability estimates.**
-
-FreqProb converts a mapping of elements to observed counts into smoothed
-probabilities that handle unseen elements sensibly. It is a general-purpose
-statistical tool — natural language processing is one consumer among many
-(information retrieval, ecology, genomics, categorical analytics, ML features).
-
-## Install
-
-```bash
-pip install freqprob
-```
-
-## A first example
-
-```python
-import freqprob
-
-counts = {"the": 100, "cat": 50, "dog": 30, "bird": 10}
-
-# Add-one (Laplace) smoothing over a vocabulary of 10,000 possible elements
-laplace = freqprob.Laplace(counts, bins=10_000, logprob=False)
-
-laplace("cat")  # 0.0050  — an observed element
-laplace("elephant")  # 0.0001  — an unseen element still gets non-zero mass
-```
-
-Every estimator follows the same contract: construct it with a frequency
-distribution, then call it to score an element.
-
-## Where to next
-
-- **[User Guide](USER_GUIDE.md)** — concepts, choosing a method, worked examples.
-- **[API Reference](reference.md)** — every public class and function, generated
-  from the source.
-
-## Choosing a method
-
-| Method | Good for | Key parameter |
-|--------|----------|---------------|
-| `MLE` | raw relative frequencies (no smoothing) | — |
-| `Laplace` / `Lidstone` / `ELE` | simple additive smoothing | `bins`, `gamma` |
-| `SimpleGoodTuring` | heavy-tailed count data | `p_value` |
-| `KneserNey` / `ModifiedKneserNey` | n-gram language models | `discount` |
-| `Bayesian` | Dirichlet-prior smoothing | `alpha` |
-| `Interpolated` | combining models of different orders | `lambda_weight` |
+---
+template: home.html
+title: FreqProb — frequency-based probability estimation
+hide:
+  - navigation
+  - toc
+---

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,12 +1,13 @@
 site_name: FreqProb
 site_description: A Python library for probability smoothing and frequency-based estimation.
-site_url: https://tresoldi.github.io/freqprob/
+site_url: https://freqprob.tresoldi.org/
 repo_url: https://github.com/tresoldi/freqprob
 repo_name: tresoldi/freqprob
 edit_uri: edit/main/docs/
 
 theme:
   name: material
+  custom_dir: overrides
   palette:
     - media: "(prefers-color-scheme: light)"
       scheme: default

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -1,0 +1,310 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>freqprob — frequency-based probability estimation</title>
+<meta name="description" content="A small, well-tested Python library that turns frequency counts into smoothed probability estimates, with consistent handling of unobserved elements.">
+<link rel="canonical" href="{{ config.site_url }}">
+<style>
+  :root {
+    --paper: #faf9f6;
+    --ink: #1b1b18;
+    --ink-2: #55534c;
+    --ink-3: #86837a;
+    --rule: #e4e1d9;
+    --rule-2: #efece5;
+    --link: #33477e;
+    --figure-bar: #3a3a34;
+    --figure-curve: #33477e;
+    --figure-unseen: #9a6b34;
+    --code-bg: #f3f1ea;
+    --serif: Charter, "Bitstream Charter", "Sitka Text", Cambria, "Iowan Old Style", Georgia, serif;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Code", Menlo, Consolas, monospace;
+    --measure: 44rem;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper: #14140f; --ink: #ece9e1; --ink-2: #b0ada2; --ink-3: #827f74;
+      --rule: #2a2a22; --rule-2: #201f19; --link: #97a8d8;
+      --figure-bar: #b8b5a8; --figure-curve: #97a8d8; --figure-unseen: #cf9d5f;
+      --code-bg: #1c1c15;
+    }
+  }
+
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0; background: var(--paper); color: var(--ink);
+    font-family: var(--serif); font-size: 18px; line-height: 1.62;
+    -webkit-font-smoothing: antialiased; text-rendering: optimizeLegibility;
+  }
+  .page { max-width: var(--measure); margin: 0 auto; padding: 0 26px 96px; }
+  a { color: var(--link); text-underline-offset: 2px; text-decoration-thickness: 0.06em; }
+  a:hover { text-decoration-thickness: 0.12em; }
+  a:focus-visible { outline: 2px solid var(--link); outline-offset: 3px; border-radius: 2px; }
+
+  header.mast { padding: 68px 0 26px; border-bottom: 1px solid var(--rule); }
+  .title { font-size: 2.2rem; font-weight: 600; letter-spacing: -0.012em; margin: 0 0 8px; }
+  .title .mono { font-family: var(--mono); font-weight: 600; }
+  .dek { font-size: 1.16rem; color: var(--ink-2); margin: 0 0 20px; max-width: 34em; }
+  .meta { font-family: var(--mono); font-size: 12.5px; color: var(--ink-3); display: flex; flex-wrap: wrap; gap: 6px 14px; align-items: baseline; }
+  .meta a { color: var(--ink-2); }
+  .meta .sep { color: var(--rule); }
+
+  main > section { padding: 32px 0; border-bottom: 1px solid var(--rule-2); }
+  main > section:last-of-type { border-bottom: 0; }
+  h2 { font-size: 0.82rem; font-weight: 700; font-family: var(--mono); letter-spacing: 0.09em; text-transform: uppercase; color: var(--ink-3); margin: 0 0 16px; }
+  p { margin: 0 0 16px; } p:last-child { margin-bottom: 0; }
+  .lead { font-size: 1.16rem; } .lead b { font-weight: 600; }
+
+  code { font-family: var(--mono); font-size: 0.86em; }
+  pre { margin: 4px 0 0; background: var(--code-bg); border: 1px solid var(--rule); border-radius: 6px; padding: 16px 18px; overflow-x: auto; font-family: var(--mono); font-size: 13.5px; line-height: 1.7; color: var(--ink); }
+  pre.install { padding: 12px 16px; font-size: 14px; }
+  .c-com { color: var(--ink-3); } .c-kw { color: var(--link); }
+  .c-str { color: #5f7a45; } .c-num { color: var(--figure-unseen); }
+  @media (prefers-color-scheme: dark) { .c-str { color: #97b06f; } }
+  .after-code { font-size: 0.98rem; color: var(--ink-2); margin-top: 14px; }
+
+  figure { margin: 6px 0 0; }
+  .fig-frame { border: 1px solid var(--rule); border-radius: 6px; background: var(--paper); padding: 14px 16px 8px; }
+  canvas { width: 100%; height: 200px; display: block; }
+  .fig-legend { font-family: var(--mono); font-size: 11px; color: var(--ink-3); display: flex; flex-wrap: wrap; gap: 16px; margin-top: 4px; padding-top: 8px; border-top: 1px solid var(--rule-2); }
+  .fig-legend span { display: inline-flex; align-items: center; gap: 6px; }
+  .fig-legend i { width: 10px; height: 10px; border-radius: 2px; display: inline-block; }
+  figcaption { font-size: 0.9rem; color: var(--ink-2); line-height: 1.5; margin-top: 12px; }
+  figcaption b { font-weight: 600; color: var(--ink); }
+
+  table { width: 100%; border-collapse: collapse; font-size: 0.94rem; }
+  thead th { font-family: var(--mono); font-size: 10.5px; letter-spacing: 0.07em; text-transform: uppercase; color: var(--ink-3); font-weight: 600; text-align: left; padding: 0 14px 8px 0; border-bottom: 1.5px solid var(--ink-3); }
+  tbody td { padding: 9px 14px 9px 0; border-bottom: 1px solid var(--rule-2); vertical-align: baseline; }
+  tbody tr:last-child td { border-bottom: 1px solid var(--ink-3); }
+  td.m { font-family: var(--mono); font-size: 0.82rem; color: var(--ink); white-space: nowrap; }
+  td.k { font-family: var(--mono); font-size: 0.8rem; color: var(--ink-3); white-space: nowrap; }
+  .tbl-scroll { overflow-x: auto; }
+
+  ul.plain { margin: 0; padding: 0; list-style: none; }
+  ul.plain li { padding: 7px 0; border-bottom: 1px solid var(--rule-2); }
+  ul.plain li:last-child { border-bottom: 0; }
+  ul.plain b { font-weight: 600; } ul.plain .d { color: var(--ink-2); }
+
+  .links-row { display: flex; flex-wrap: wrap; gap: 4px 22px; font-size: 1rem; }
+
+  footer { padding-top: 30px; margin-top: 8px; border-top: 1px solid var(--rule); font-family: var(--mono); font-size: 12.5px; color: var(--ink-3); display: flex; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+
+  @media (prefers-reduced-motion: reduce) { * { animation: none !important; } }
+</style>
+</head>
+<body>
+<div class="page">
+  <header class="mast">
+    <h1 class="title"><span class="mono">freqprob</span></h1>
+    <p class="dek">Frequency-based probability estimation with smoothing — a small,
+      well-tested Python library.</p>
+    <div class="meta">
+      <span>MIT</span><span class="sep">·</span>
+      <span>Python 3.10–3.12</span><span class="sep">·</span>
+      <a href="https://github.com/tresoldi/freqprob">GitHub</a><span class="sep">·</span>
+      <a href="https://pypi.org/project/freqprob/">PyPI</a><span class="sep">·</span>
+      <a href="{{ base_url }}/USER_GUIDE/">Documentation</a>
+    </div>
+  </header>
+
+  <main>
+    <section>
+      <p class="lead">The central difficulty in working with frequency counts is the
+        unobserved: how much probability to assign to events that never appeared in
+        the data. FreqProb converts counts into <b>smoothed</b> probability estimates
+        that address this directly — reserving a principled share of mass for what was
+        not seen — and offers a range of classical smoothing methods, from Laplace and
+        Lidstone to Simple Good-Turing and Kneser-Ney, behind a single, consistent
+        interface.</p>
+    </section>
+
+    <section>
+      <h2>Installation</h2>
+      <pre class="install">pip install freqprob</pre>
+    </section>
+
+    <section>
+      <h2>Example</h2>
+<pre><span class="c-kw">import</span> freqprob
+
+counts = {<span class="c-str">"the"</span>: <span class="c-num">100</span>, <span class="c-str">"cat"</span>: <span class="c-num">50</span>, <span class="c-str">"dog"</span>: <span class="c-num">30</span>, <span class="c-str">"bird"</span>: <span class="c-num">10</span>}
+model = freqprob.Laplace(counts, bins=<span class="c-num">10_000</span>, logprob=<span class="c-kw">False</span>)
+
+model(<span class="c-str">"cat"</span>)       <span class="c-com"># 0.0050   observed element</span>
+model(<span class="c-str">"elephant"</span>)  <span class="c-com"># 0.0001   unobserved, yet non-zero</span></pre>
+      <p class="after-code">A maximum-likelihood estimate would assign probability
+        zero to <code>"elephant"</code>, which is undefined under a logarithm and
+        collapses any product of probabilities. Smoothing reserves a small amount of
+        probability mass for the unobserved; the estimator is selected by construction
+        and the call site does not change.</p>
+    </section>
+
+    <section>
+      <h2>The estimate</h2>
+      <figure>
+        <div class="fig-frame">
+          <canvas id="viz" width="720" height="200"></canvas>
+          <div class="fig-legend">
+            <span><i style="background:var(--figure-bar)"></i>observed counts</span>
+            <span><i style="background:var(--figure-curve)"></i>smoothed probability</span>
+            <span><i style="background:var(--figure-unseen)"></i>reserved for unobserved</span>
+          </div>
+        </div>
+        <figcaption><b>Figure 1.</b> Observed counts (bars) are normalised into a
+          smoothed probability distribution (curve). A share of the total mass is
+          held back for elements that were never observed, shown at right.</figcaption>
+      </figure>
+    </section>
+
+    <section>
+      <h2>Methods</h2>
+      <div class="tbl-scroll">
+        <table>
+          <thead>
+            <tr><th>Estimator</th><th>Appropriate when</th><th>Parameter</th></tr>
+          </thead>
+          <tbody>
+            <tr><td class="m">MLE</td><td>relative frequencies are wanted, without smoothing</td><td class="k">—</td></tr>
+            <tr><td class="m">Laplace, Lidstone, ELE</td><td>simple additive smoothing suffices</td><td class="k">bins, gamma</td></tr>
+            <tr><td class="m">SimpleGoodTuring</td><td>the distribution is heavy-tailed with many rare types</td><td class="k">p_value</td></tr>
+            <tr><td class="m">KneserNey, ModifiedKneserNey</td><td>estimating an n-gram language model</td><td class="k">discount</td></tr>
+            <tr><td class="m">Bayesian</td><td>a Dirichlet prior is assumed</td><td class="k">alpha</td></tr>
+            <tr><td class="m">Interpolated</td><td>a specific and a general model are combined</td><td class="k">lambda_weight</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+
+    <section>
+      <h2>Beyond text</h2>
+      <p>The problem — estimating probabilities from counts, including for the
+        unobserved — recurs across fields. FreqProb is domain-neutral:</p>
+      <ul class="plain">
+        <li><b>Text.</b> <span class="d">n-gram and word-frequency models; term weighting.</span></li>
+        <li><b>Ecology.</b> <span class="d">species-abundance data and the classical unseen-species problem.</span></li>
+        <li><b>Genomics.</b> <span class="d">k-mer frequencies over the space of possible subsequences.</span></li>
+        <li><b>Categorical data.</b> <span class="d">smoothed category priors for features and event counts.</span></li>
+      </ul>
+    </section>
+
+    <section>
+      <h2>Documentation</h2>
+      <div class="links-row">
+        <a href="{{ base_url }}/USER_GUIDE/">User Guide →</a>
+        <a href="{{ base_url }}/reference/">API Reference →</a>
+        <a href="https://github.com/tresoldi/freqprob/blob/main/CHANGELOG.md">Changelog →</a>
+        <a href="https://github.com/tresoldi/freqprob">Source (GitHub) →</a>
+        <a href="https://pypi.org/project/freqprob/">Package (PyPI) →</a>
+      </div>
+    </section>
+
+    <section>
+      <h2>Citation</h2>
+<pre>@software{tresoldi_freqprob_2026,
+  author  = {Tresoldi, Tiago},
+  title   = {FreqProb: A Python library for probability smoothing
+             and frequency-based estimation},
+  year    = {2026},
+  version = {0.6.2},
+  url     = {https://github.com/tresoldi/freqprob}
+}</pre>
+    </section>
+  </main>
+
+  <footer>
+    <span>MIT License</span>
+    <span>© 2026 Tiago Tresoldi</span>
+  </footer>
+</div>
+
+<script>
+  (function () {
+    var canvas = document.getElementById("viz");
+    if (!canvas) return;
+    var ctx = canvas.getContext("2d");
+    var reduce = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    function css(v) { return getComputedStyle(document.documentElement).getPropertyValue(v).trim(); }
+
+    var counts = [100, 50, 30, 22, 14, 9, 6, 4, 3, 2];
+    var total = counts.reduce(function (a, b) { return a + b; }, 0);
+    var unseenMass = 0.02;
+
+    function dims() {
+      var ratio = window.devicePixelRatio || 1;
+      var w = canvas.clientWidth, h = canvas.clientHeight;
+      canvas.width = w * ratio; canvas.height = h * ratio;
+      ctx.setTransform(ratio, 0, 0, ratio, 0, 0);
+      return { w: w, h: h };
+    }
+    function topRect(x, y, w, h, r) {
+      r = Math.min(r, w / 2, Math.max(h, 0));
+      ctx.beginPath(); ctx.moveTo(x, y + h); ctx.lineTo(x, y + r);
+      ctx.quadraticCurveTo(x, y, x + r, y); ctx.lineTo(x + w - r, y);
+      ctx.quadraticCurveTo(x + w, y, x + w, y + r); ctx.lineTo(x + w, y + h); ctx.closePath();
+    }
+    function draw(t) {
+      var d = dims(), w = d.w, h = d.h;
+      ctx.clearRect(0, 0, w, h);
+      var bar = css("--figure-bar"), curve = css("--figure-curve"),
+          unseen = css("--figure-unseen"), rule = css("--rule");
+      var padL = 4, padR = 4, padB = 22, padT = 14;
+      var plotH = h - padT - padB, plotW = w - padL - padR;
+      var n = counts.length, slot = plotW / (n + 1.5), barW = slot * 0.5;
+      var norm = counts[0] / total;
+
+      ctx.strokeStyle = rule; ctx.lineWidth = 1;
+      ctx.beginPath(); ctx.moveTo(padL, padT + plotH + 0.5); ctx.lineTo(w - padR, padT + plotH + 0.5); ctx.stroke();
+
+      var i;
+      for (i = 0; i < n; i++) {
+        var bh = (counts[i] / counts[0]) * plotH * t;
+        var x = padL + slot * (i + 0.5) - barW / 2;
+        ctx.fillStyle = bar; ctx.globalAlpha = 0.78;
+        topRect(x, padT + plotH - bh, barW, bh, 1.5); ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+
+      var ce = Math.max(0, (t - 0.4) / 0.6);
+      if (ce > 0) {
+        var pts = [];
+        for (i = 0; i < n; i++) {
+          var px = padL + slot * (i + 0.5);
+          var py = padT + plotH - ((counts[i] / total) / norm) * plotH * 0.9;
+          pts.push([px, py]);
+        }
+        pts.push([padL + slot * (n + 0.6), padT + plotH - (unseenMass / norm) * plotH * 0.9]);
+        var drawN = Math.max(2, Math.floor(pts.length * ce));
+        ctx.strokeStyle = curve; ctx.lineWidth = 1.75; ctx.beginPath();
+        ctx.moveTo(pts[0][0], pts[0][1]);
+        for (i = 1; i < drawN; i++) {
+          var p0 = pts[i - 1], p1 = pts[i];
+          ctx.quadraticCurveTo((p0[0] + p1[0]) / 2, p0[1], p1[0], p1[1]);
+        }
+        ctx.stroke();
+      }
+
+      var uh = (unseenMass / norm) * plotH * 0.9 * t;
+      var xu = padL + slot * (n + 0.6) - barW / 2;
+      ctx.fillStyle = unseen; ctx.globalAlpha = 0.9;
+      topRect(xu, padT + plotH - Math.max(uh, 1.5), barW, Math.max(uh, 1.5), 1.5); ctx.fill();
+      ctx.globalAlpha = 1;
+      ctx.fillStyle = unseen; ctx.font = "10px " + css("--mono"); ctx.textAlign = "center";
+      ctx.fillText("unseen", xu + barW / 2, padT + plotH + 15);
+    }
+
+    var start = null;
+    function frame(ts) {
+      if (start === null) start = ts;
+      var t = Math.min(1, (ts - start) / 900);
+      draw(1 - Math.pow(1 - t, 3));
+      if (t < 1) requestAnimationFrame(frame);
+    }
+    if (reduce) { draw(1); } else { requestAnimationFrame(frame); }
+    window.addEventListener("resize", function () { draw(1); });
+  })();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Adds a dedicated **documentation landing page** in front of the existing docs, and moves the site to the custom domain **`https://freqprob.tresoldi.org`**. The site already deploys on every push to `main` via `docs.yml` — no pipeline change.

## Landing page

A chromeless, academic **"monograph"** design (the direction we converged on — dry, a step up from the README, not SaaS-y): lead paragraph opening on the core difficulty of the unobserved, install, an example, a captioned **Figure 1** visualizing counts → smoothed distribution with mass reserved for the unseen, a methods table, the four domains, documentation links, and a BibTeX citation.

It's implemented as a **MkDocs custom home template** (`overrides/home.html`) — a self-contained page, so it renders pixel-faithfully without fighting Material's CSS. The **User Guide** and **API Reference** keep the standard Material navigation behind it; the home links into them.

- `theme.custom_dir: overrides`; `docs/index.md` uses `template: home.html`.

## Custom domain

- `docs/CNAME` → `freqprob.tresoldi.org`; `site_url` and README links updated.

## Verification

`mkdocs build --strict` succeeds, emits the `CNAME`, resolves the in-page doc links (`./USER_GUIDE/`, `./reference/`), and renders the home chromeless while the docs keep Material chrome. `ruff` + the doc-example/doctest tests pass.

## ⚠️ One manual step (DNS) — needed for the domain to resolve

At your DNS provider for `tresoldi.org`, add:

```
freqprob   CNAME   tresoldi.github.io.
```

After DNS propagates and this merges, GitHub Pages picks up the `CNAME` file automatically; then enable **Enforce HTTPS** in Settings → Pages once the certificate provisions. Until the DNS record exists, the site stays reachable at the old `tresoldi.github.io/freqprob/` URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_