### PR TITLE
release: finalize 0.6.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.6.2] - 2026-07-28
+
+Maintenance release: license/metadata fixes, a full documentation rebuild, and a
+new documentation landing page. No library code or public API changes since
+0.6.1.
 
 ### Added
 
@@ -27,14 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `CertaintyDegree` (marked experimental) and `WittenBell` throughout, and
   reorganised the README method table so both are described accurately rather
   than lumped under "baselines."
-
-## [0.6.2] - 2026-07-28
-
-Maintenance release: license/metadata fixes and a full documentation rebuild.
-No library code or public API changes since 0.6.1.
-
-### Fixed
-
 - **License file corrected to MIT.** The `LICENSE` file contained the full GNU
   GPL v3 text, contradicting the MIT license declared in `pyproject.toml`,
   `CITATION.cff`, and the README. Replaced it with the MIT License text so all


### PR DESCRIPTION
## Summary

Finalizes the CHANGELOG for the **0.6.2** release.

`0.6.2` was prepared earlier but **never tagged or published** — PyPI is still on `0.6.1`, and there is no `v0.6.2` git tag. Since then, further docs-only work landed (the dry landing page, the custom domain, and the `CertaintyDegree`/`WittenBell` coverage fixes). Rather than skip to a phantom `0.6.3`, this folds those unreleased entries into the `[0.6.2]` section.

- Moved the `[Unreleased]` **Added** (landing page, custom domain) and **Fixed** (method coverage) entries into `[0.6.2] - 2026-07-28`.
- Updated the 0.6.2 summary line to mention the new landing page.
- No library code or public API changes; the source version is already `0.6.2`.

## Verification

- Full suite: **361 passed, 5 skipped, 91.15% coverage** (gate 88%).
- `python -m build` produces the sdist + wheel; `twine check` **passes** with current tooling (packaging ≥ 24.2 / twine 7) — this is the first release to emit the PEP 639 `License-Expression: MIT` metadata, and it validates. The Release workflow installs fresh `build`/`twine`, so its metadata-check step will pass.

## After merge

Publishing is driven by pushing the `v0.6.2` tag (the `release.yml` workflow builds and publishes to PyPI via trusted publishing). That tag push needs to come from a context with `workflow` scope — see the merge/tag note in the conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_