### PR TITLE
feat: back-off/discounting smoothers, Jelinek-Mercer, and entropy estimators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **New bigram smoothing methods.** `AbsoluteDiscounting` and `PitmanYor`
+  (absolute discounting and its Pitman-Yor generalization, backing off to a
+  unigram model), and `KatzBackoff` and `StupidBackoff` (Good-Turing-normalized
+  and fast unnormalized back-off). They share internal machinery in
+  `methods/_bigram.py` and model `P(word | context)` over `(context, word)`
+  bigram distributions.
+- **`JelinekMercer` smoothing.** Linear interpolation whose weight is fit by EM
+  (deleted interpolation) on a held-out distribution, exposed via
+  `estimated_lambda`; falls back to a fixed weight when no held-out data is given.
+- **Sample-based entropy estimators** in `metrics`: `sample_coverage` (the
+  Good-Turing observed-mass estimate), `chao_shen_entropy` (Chao-Shen
+  bias-corrected entropy), and `nsb_entropy` (the Nemenman-Shafee-Bialek Bayesian
+  entropy estimator, with an optional `bins` for the assumed alphabet size).
+- All new estimators and functions are exported from the top-level `freqprob`
+  namespace and covered by `tests/test_new_methods.py`.
+
 ## [0.6.2] - 2026-07-28
 
 Maintenance release: license/metadata fixes, a full documentation rebuild, and a

--- a/README.md
+++ b/README.md
@@ -65,15 +65,19 @@ any fitted estimator can be saved with `.save(path)` and reloaded with
 | `Laplace` / `Lidstone` / `ELE` | simple, robust additive smoothing | `bins`, `gamma` |
 | `SimpleGoodTuring` | heavy-tailed count data (many rare items) | `p_value` |
 | `KneserNey` / `ModifiedKneserNey` | n-gram language models | `discount` |
+| `AbsoluteDiscounting` / `PitmanYor` | bigram discounting with unigram back-off | `discount`, `strength` |
+| `KatzBackoff` / `StupidBackoff` | bigram back-off models | `k`, `alpha` |
 | `WittenBell` | parameter-free discounting by distinct-type count | `bins` |
 | `Bayesian` | Dirichlet-prior smoothing | `alpha` |
-| `Interpolated` | combining models of different orders | `lambda_weight` |
+| `Interpolated` / `JelinekMercer` | combining models of different orders (fixed or EM-fit weight) | `lambda_weight` |
 | `CertaintyDegree` | reserving mass by how fully the support is observed (experimental) | `bins` |
 | `Uniform` / `Random` | non-informative baselines | — |
 
 For large or streaming data, FreqProb also provides vectorized batch scoring,
 lazy evaluation, streaming (incremental) estimators, and memory-efficient
-compressed/sparse representations.
+compressed/sparse representations. Sample-based estimators — `sample_coverage`
+and the bias-corrected entropy estimators `chao_shen_entropy` and `nsb_entropy`
+— work directly on a frequency distribution.
 
 ## Why FreqProb
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -88,8 +88,10 @@ Start from what your data looks like:
 | Heavy-tailed counts, many rare elements | `SimpleGoodTuring` | `p_value` |
 | Parameter-free discounting by distinct-type count | `WittenBell` | `bins` |
 | n-gram language models | `KneserNey` / `ModifiedKneserNey` | `discount` |
+| Bigram discounting with unigram back-off | `AbsoluteDiscounting` / `PitmanYor` | `discount`, `strength` |
+| Bigram back-off (normalised or fast) | `KatzBackoff` / `StupidBackoff` | `k`, `alpha` |
 | You have a prior belief (Dirichlet) | `Bayesian` | `alpha` |
-| Combine a specific and a general model | `Interpolated` | `lambda_weight` |
+| Combine a specific and a general model | `Interpolated` / `JelinekMercer` | `lambda_weight` |
 | Reserve mass by how fully the support is observed (experimental) | `CertaintyDegree` | `bins` |
 | Non-informative baseline | `Uniform` / `Random` | — |
 
@@ -114,8 +116,16 @@ When-to-use, in one line each:
   things seen; a solid, assumption-light choice.
 - **`KneserNey`** — the standard for n-gram models; models how likely an element
   is to appear in a *novel* context.
+- **`AbsoluteDiscounting`** / **`PitmanYor`** — bigram discounting that backs off
+  to a unigram model; `PitmanYor` adds a concentration parameter (`strength`) and
+  has absolute discounting as its `strength=0` case.
+- **`KatzBackoff`** / **`StupidBackoff`** — bigram back-off; Katz is a proper
+  normalized distribution (Good-Turing discounted), Stupid Back-off is a fast,
+  unnormalized score for ranking at scale.
 - **`Bayesian`** — smoothing as a Dirichlet(`alpha`) prior; principled and tunable.
 - **`Interpolated`** — mix a high-order (specific) and low-order (general) model.
+- **`JelinekMercer`** — interpolation whose weight is fit by EM on held-out data
+  (falls back to a fixed weight when none is given).
 - **`CertaintyDegree`** — reserves mass by how fully the possible support has been
   observed; the more of the space you have seen, the less is held back.
   *Experimental — not recommended as your only estimator yet.*
@@ -196,11 +206,44 @@ assert 0.0 < kn(("the", "cat")) <= 1.0
 assert kn(("the", "bird")) > 0.0  # unseen bigram still gets mass
 ```
 
-### Priors and interpolation: Bayesian, Interpolated
+### Bigram back-off and discounting: AbsoluteDiscounting, PitmanYor, KatzBackoff, StupidBackoff
+
+These take a distribution over `(context, word)` bigrams and model
+`P(word | context)`, discounting observed bigrams and backing off to a unigram
+model for unseen ones. `AbsoluteDiscounting` subtracts a fixed amount from each
+count; `PitmanYor` generalises it with a concentration parameter (`strength`),
+recovering absolute discounting at `strength=0`. `KatzBackoff` uses Good-Turing
+discounting and normalised back-off weights, so it is a proper distribution;
+`StupidBackoff` skips normalisation for speed and returns scores (not
+probabilities) for ranking at scale.
+
+```python
+import freqprob
+
+bigrams = {
+    ("the", "cat"): 5,
+    ("the", "dog"): 3,
+    ("a", "cat"): 2,
+    ("a", "dog"): 1,
+    ("big", "cat"): 1,
+    ("small", "dog"): 1,
+}
+
+ad = freqprob.AbsoluteDiscounting(bigrams, discount=0.75, logprob=False)
+assert ad(("the", "cat")) > 0
+assert ad(("new", "cat")) > 0  # unseen context backs off to the unigram model
+
+sb = freqprob.StupidBackoff(bigrams, alpha=0.4, logprob=False)
+assert sb(("the", "cat")) == 0.625  # observed bigram scores its relative frequency (5/8)
+```
+
+### Priors and interpolation: Bayesian, Interpolated, JelinekMercer
 
 `Bayesian` treats smoothing as a Dirichlet(`alpha`) prior over categories.
 `Interpolated` blends a high-order (specific) distribution with a low-order
-(general) one via `lambda_weight`.
+(general) one via a fixed `lambda_weight`. `JelinekMercer` is the same
+interpolation, but fits the weight by EM on a held-out distribution when one is
+supplied (otherwise it uses the fixed weight).
 
 ```python
 import freqprob
@@ -210,6 +253,12 @@ low = {"cat": 3, "dog": 2, "the": 5}
 interp = freqprob.Interpolated(high, low, lambda_weight=0.7, logprob=False)
 
 assert 0.0 <= interp(("the", "big", "cat")) <= 1.0
+
+# Jelinek-Mercer fits the interpolation weight from held-out data.
+trigrams = {("the", "big", "cat"): 3, ("a", "big", "dog"): 2}
+bigrams = {("big", "cat"): 5, ("big", "dog"): 3}
+jm = freqprob.JelinekMercer(trigrams, bigrams, lambda_weight=0.6, logprob=False)
+assert round(jm.estimated_lambda, 2) == 0.6  # no held-out data -> fixed weight
 ```
 
 ### Certainty-degree smoothing: CertaintyDegree
@@ -268,6 +317,27 @@ models = {
 }
 report = freqprob.model_comparison(models, test)
 assert set(report) == {"laplace", "mle"}
+```
+
+### Coverage and entropy of a sample
+
+These work directly on a frequency distribution rather than on a fitted model.
+`sample_coverage` is the Good-Turing estimate of the observed probability mass
+(one minus the singleton rate). `chao_shen_entropy` and `nsb_entropy` estimate
+Shannon entropy while correcting the downward bias of the naive plug-in estimate
+when the sample misses mass — useful for undersampled data. `nsb_entropy` takes
+an optional `bins` to reserve entropy for types that could occur but were not
+seen.
+
+```python
+import freqprob
+
+counts = {"a": 8, "b": 1, "c": 1}  # two singletons out of ten observations
+
+assert freqprob.sample_coverage(counts) == 0.8  # 1 - 2/10
+# Both estimators exceed the (biased-low) plug-in entropy on undersampled data.
+assert freqprob.chao_shen_entropy(counts) > 0.0
+assert freqprob.nsb_entropy(counts, bins=100) > freqprob.nsb_entropy(counts)
 ```
 
 ---

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -169,8 +169,10 @@ model("elephant")  <span class="c-com"># 0.0001   unobserved, yet non-zero</span
             <tr><td class="m">SimpleGoodTuring</td><td>the distribution is heavy-tailed with many rare types</td><td class="k">p_value</td></tr>
             <tr><td class="m">WittenBell</td><td>a parameter-free discount tied to the number of distinct types is wanted</td><td class="k">bins</td></tr>
             <tr><td class="m">KneserNey, ModifiedKneserNey</td><td>estimating an n-gram language model</td><td class="k">discount</td></tr>
+            <tr><td class="m">AbsoluteDiscounting, PitmanYor</td><td>bigram discounting with back-off to a unigram model</td><td class="k">discount, strength</td></tr>
+            <tr><td class="m">KatzBackoff, StupidBackoff</td><td>bigram back-off, normalised (Katz) or fast and unnormalised (Stupid)</td><td class="k">k, alpha</td></tr>
             <tr><td class="m">Bayesian</td><td>a Dirichlet prior is assumed</td><td class="k">alpha</td></tr>
-            <tr><td class="m">Interpolated</td><td>a specific and a general model are combined</td><td class="k">lambda_weight</td></tr>
+            <tr><td class="m">Interpolated, JelinekMercer</td><td>a specific and a general model are combined, with a fixed or EM-fitted weight</td><td class="k">lambda_weight</td></tr>
             <tr><td class="m">CertaintyDegree</td><td>mass is reserved by how fully the support has been observed (experimental)</td><td class="k">bins</td></tr>
             <tr><td class="m">Uniform, Random</td><td>a non-informative baseline is needed</td><td class="k">—</td></tr>
           </tbody>

--- a/src/freqprob/__init__.py
+++ b/src/freqprob/__init__.py
@@ -12,15 +12,25 @@ from .base import ScoringMethod
 # Core estimators, grouped by family under methods/
 from .cache import clear_all_caches, get_cache_stats
 from .methods.additive import ELE, Laplace, Lidstone
+from .methods.backoff import KatzBackoff, StupidBackoff
 from .methods.baselines import MLE, Random, Uniform
 from .methods.bayesian import Bayesian
 from .methods.certainty import CertaintyDegree
+from .methods.discounting import AbsoluteDiscounting, PitmanYor
 from .methods.goodturing import SimpleGoodTuring, WittenBell
-from .methods.interpolated import Interpolated
+from .methods.interpolated import Interpolated, JelinekMercer
 from .methods.kneser_ney import KneserNey, ModifiedKneserNey
 
 # Model-evaluation metrics and (NLP) text helpers
-from .metrics import cross_entropy, kl_divergence, model_comparison, perplexity
+from .metrics import (
+    chao_shen_entropy,
+    cross_entropy,
+    kl_divergence,
+    model_comparison,
+    nsb_entropy,
+    perplexity,
+    sample_coverage,
+)
 
 # Performance infrastructure (lazy/streaming/vectorized/memory/profiling)
 from .performance.lazy import (
@@ -50,12 +60,15 @@ from .text import generate_ngrams, ngram_frequency, word_frequency
 __all__ = [
     "ELE",
     "MLE",
+    "AbsoluteDiscounting",
     "BatchScorer",
     "Bayesian",
     "CertaintyDegree",
     "CompressedFrequencyDistribution",
     "DistributionMemoryAnalyzer",
     "Interpolated",
+    "JelinekMercer",
+    "KatzBackoff",
     "KneserNey",
     "Laplace",
     "LazyBatchScorer",
@@ -64,6 +77,7 @@ __all__ = [
     "MemoryMonitor",
     "MemoryProfiler",
     "ModifiedKneserNey",
+    "PitmanYor",
     "QuantizedProbabilityTable",
     "Random",
     "ScoringMethod",
@@ -73,9 +87,11 @@ __all__ = [
     "StreamingFrequencyDistribution",
     "StreamingLaplace",
     "StreamingMLE",
+    "StupidBackoff",
     "Uniform",
     "VectorizedScorer",
     "WittenBell",
+    "chao_shen_entropy",
     "clear_all_caches",
     "create_compressed_distribution",
     "create_lazy_laplace",
@@ -88,6 +104,8 @@ __all__ = [
     "kl_divergence",
     "model_comparison",
     "ngram_frequency",
+    "nsb_entropy",
     "perplexity",
+    "sample_coverage",
     "word_frequency",
 ]

--- a/src/freqprob/methods/_bigram.py
+++ b/src/freqprob/methods/_bigram.py
@@ -1,0 +1,126 @@
+"""Internal machinery shared by the bigram back-off / discounting smoothers.
+
+`AbsoluteDiscounting`, `KatzBackoff`, `StupidBackoff`, and `PitmanYor` all model
+a conditional distribution ``P(word | context)`` from a frequency distribution
+over ``(context, word)`` bigrams. They differ only in how observed bigrams are
+discounted and how much mass is backed off to the lower-order (unigram) model;
+the bookkeeping — extracting counts and scoring unseen bigrams by backing off to
+the unigram distribution — is identical, and lives here.
+
+Like the Kneser-Ney implementation, any key that is not a length-2 tuple is
+ignored, so a distribution may mix bigrams with other bookkeeping entries.
+"""
+
+import math
+
+from freqprob.base import (
+    MIN_PROBABILITY,
+    Element,
+    FrequencyDistribution,
+    LogProbability,
+    Probability,
+    ScoringMethod,
+    ScoringMethodConfig,
+)
+
+
+def extract_bigram_stats(
+    freqdist: FrequencyDistribution,
+) -> tuple[
+    dict[Element, int],
+    dict[Element, set[Element]],
+    dict[tuple[Element, Element], int],
+    dict[Element, int],
+    int,
+]:
+    """Extract the counts the bigram smoothers need from a distribution.
+
+    Args:
+        freqdist: Mapping of ``(context, word)`` bigrams to counts. Non-bigram
+            keys are ignored.
+
+    Returns:
+        A tuple ``(context_total, context_types, context_word, unigram, total)``
+        where ``context_total[c]`` is ``c(context)``, ``context_types[c]`` is the
+        set of distinct words following the context, ``context_word[(c, w)]`` is
+        ``c(context, word)``, ``unigram[w]`` is the total number of times a word
+        appears in the second position, and ``total`` is the grand total of all
+        bigram counts.
+    """
+    context_total: dict[Element, int] = {}
+    context_types: dict[Element, set[Element]] = {}
+    context_word: dict[tuple[Element, Element], int] = {}
+    unigram: dict[Element, int] = {}
+    total = 0
+
+    for element, count in freqdist.items():
+        if not (isinstance(element, tuple) and len(element) == 2):
+            continue
+        context, word = element
+        context_total[context] = context_total.get(context, 0) + count
+        context_types.setdefault(context, set()).add(word)
+        key = (context, word)
+        context_word[key] = context_word.get(key, 0) + count
+        unigram[word] = unigram.get(word, 0) + count
+        total += count
+
+    return context_total, context_types, context_word, unigram, total
+
+
+class BigramBackoff(ScoringMethod):
+    """Base class for bigram smoothers that back off to a unigram model.
+
+    Subclasses populate, in :meth:`_compute_probabilities`:
+
+    - ``self._prob``: scores for observed bigrams,
+    - ``self._lower``: the lower-order (unigram) probability of each word,
+    - ``self._backoff``: a per-context back-off weight applied to the unigram
+      probability of a word unseen in that context, and
+    - ``self._unknown_context_weight``: the back-off weight used when the whole
+      context is unseen (``1.0`` for the discounting methods, ``alpha`` for
+      Stupid Back-off),
+
+    and this base class handles scoring, including the on-the-fly back-off for
+    unseen bigrams (mirroring the approach used by ``Interpolated``).
+    """
+
+    __slots__ = ("_backoff", "_lower", "_unknown_context_weight")
+
+    def __init__(self, config: ScoringMethodConfig) -> None:
+        """Initialize the shared back-off state."""
+        super().__init__(config)
+        self._lower: dict[Element, float] = {}
+        self._backoff: dict[Element, float] = {}
+        self._unknown_context_weight: float = 1.0
+
+    def __call__(self, element: Element) -> Probability | LogProbability:
+        """Score a bigram, backing off to the unigram model when unseen.
+
+        Observed bigrams return their stored score. For an unseen bigram
+        ``(context, word)`` the score is ``weight * P_lower(word)``, where the
+        weight is the context's back-off weight (or
+        :attr:`_unknown_context_weight` when the context itself is unseen).
+        """
+        stored = self._prob.get(element)
+        if stored is not None:
+            return stored
+
+        if isinstance(element, tuple) and len(element) == 2:
+            context, word = element
+            lower = self._lower.get(word, 0.0)
+            weight = self._backoff.get(context, self._unknown_context_weight)
+            prob = max(weight * lower, MIN_PROBABILITY)
+            return math.log(prob) if self.logprob else prob
+
+        return self._unobs
+
+    def _store_observed(self, key: tuple[Element, Element], prob: float) -> None:
+        """Store one observed-bigram score, honoring the log/plain setting."""
+        prob = max(prob, MIN_PROBABILITY)
+        self._prob[key] = math.log(prob) if self.logprob else prob
+
+    def _finalize(self, lower: dict[Element, float], vocab_size: int) -> None:
+        """Record the unigram model and the fallback for non-bigram queries."""
+        self._lower = lower
+        uniform = 1.0 / vocab_size if vocab_size else MIN_PROBABILITY
+        self._unobs = math.log(uniform) if self.logprob else uniform

--- a/src/freqprob/methods/backoff.py
+++ b/src/freqprob/methods/backoff.py
@@ -1,0 +1,244 @@
+"""Katz and Stupid Back-off bigram smoothing.
+
+Both methods score an observed bigram directly and fall back to a lower-order
+unigram model for unseen bigrams. Katz back-off discounts observed counts with
+Good-Turing and computes normalized back-off weights so the result is a proper
+probability distribution; Stupid Back-off skips normalization for speed and
+returns unnormalized scores.
+"""
+
+import math
+from collections import Counter
+from dataclasses import dataclass
+
+from freqprob.base import FrequencyDistribution, ScoringMethodConfig
+from freqprob.methods._bigram import BigramBackoff, extract_bigram_stats
+
+
+@dataclass
+class KatzBackoffConfig(ScoringMethodConfig):
+    """Configuration for Katz back-off smoothing.
+
+    Attributes:
+        k: Count threshold below which Good-Turing discounting is applied.
+            Counts greater than ``k`` are treated as reliable and left
+            undiscounted (default: ``5``).
+    """
+
+    k: int = 5
+
+
+@dataclass
+class StupidBackoffConfig(ScoringMethodConfig):
+    """Configuration for Stupid Back-off scoring.
+
+    Attributes:
+        alpha: Fixed back-off weight applied at each fall-back to the lower-order
+            model (default: ``0.4``).
+    """
+
+    alpha: float = 0.4
+
+
+class KatzBackoff(BigramBackoff):
+    """Katz back-off bigram smoothing.
+
+    Katz's method discounts observed bigram counts with Good-Turing and
+    redistributes the freed mass to a lower-order unigram model through
+    normalized back-off weights. Following Katz (1987), only counts up to a
+    threshold ``k`` are discounted (counts above ``k`` are assumed reliable). For
+    a bigram ``(context, word)`` with count ``c`` and context total ``C``,
+
+    ``P(word | context) = d_c * c / C``      if ``c > 0``,
+
+    ``P(word | context) = alpha(context) * P_uni(word)``    otherwise,
+
+    where ``d_c`` is the Good-Turing discount ratio for count ``c`` and
+    ``alpha(context)`` is chosen so each context's distribution sums to one. It
+    is one of the classic n-gram smoothing methods and pairs naturally with
+    :class:`~freqprob.SimpleGoodTuring`, which uses the same count-of-counts
+    machinery.
+
+    Args:
+        freqdist: Frequency distribution mapping ``(context, word)`` bigrams to
+            counts. Non-bigram keys are ignored.
+        k: Good-Turing discounting is applied to counts ``1 <= c <= k``; larger
+            counts are left undiscounted. Defaults to ``5``.
+        logprob: Return log-probabilities if ``True`` (the default), otherwise
+            plain probabilities.
+
+    Examples:
+        Reliable (high) counts are barely discounted, rare counts are discounted
+        more, and unseen bigrams back off to the unigram model:
+
+        >>> bigram_counts = {
+        ...     ("the", "cat"): 4, ("the", "dog"): 3,
+        ...     ("a", "cat"): 2, ("a", "dog"): 2,
+        ...     ("my", "cat"): 1, ("my", "dog"): 1, ("my", "bird"): 1,
+        ...     ("his", "fish"): 1, ("her", "fish"): 1, ("its", "bird"): 1,
+        ... }
+        >>> katz = KatzBackoff(bigram_counts, logprob=False)
+        >>> round(katz(("the", "cat")), 3)    # reliable count, undiscounted
+        0.571
+        >>> round(katz(("my", "cat")), 3)     # singleton, Good-Turing discounted
+        0.222
+        >>> round(katz(("my", "fish")), 3)    # unseen in context, backs off
+        0.333
+
+    Note:
+        This implementation assumes bigram input. Good-Turing discounting needs a
+        spread of low counts (singletons, doubletons, ...) to estimate discounts;
+        with too few distinct counts some discounts default to ``1`` (no
+        discounting), leaving little or no mass for unseen bigrams.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        freqdist: FrequencyDistribution,
+        k: int = 5,
+        logprob: bool = True,
+    ) -> None:
+        """Initialize Katz back-off smoothing."""
+        if k < 1:
+            raise ValueError("Threshold k must be a positive integer")
+
+        config = KatzBackoffConfig(k=k, logprob=logprob)
+        super().__init__(config)
+        self.name = "Katz Back-off"
+        self.fit(freqdist)
+
+    def _compute_probabilities(self, freqdist: FrequencyDistribution) -> None:
+        """Compute Katz back-off probabilities."""
+        k = self.config.k  # type: ignore[attr-defined]
+
+        context_total, context_types, context_word, unigram, total = extract_bigram_stats(freqdist)
+
+        lower = {word: count / total for word, count in unigram.items()} if total else {}
+
+        # Good-Turing discount ratios d_r for counts 1..k, following Katz (1987).
+        count_of_counts = Counter(context_word.values())
+        n1 = count_of_counts.get(1, 0)
+        nk1 = count_of_counts.get(k + 1, 0)
+        a = (k + 1) * nk1 / n1 if n1 else 0.0
+
+        discount_ratio: dict[int, float] = {}
+        for r in range(1, k + 1):
+            nr = count_of_counts.get(r, 0)
+            nr1 = count_of_counts.get(r + 1, 0)
+            if nr and nr1 and (1 - a) != 0:
+                r_star = (r + 1) * nr1 / nr
+                d_r = (r_star / r - a) / (1 - a)
+                discount_ratio[r] = min(max(d_r, 0.0), 1.0)
+            else:
+                discount_ratio[r] = 1.0  # cannot estimate: leave undiscounted
+
+        def discount(count: int) -> float:
+            return discount_ratio.get(count, 1.0) if count <= k else 1.0
+
+        # Observed-bigram probabilities and per-context back-off weights.
+        for context, ctotal in context_total.items():
+            used = 0.0
+            remaining_lower = 1.0
+            for word in context_types[context]:
+                count = context_word[(context, word)]
+                prob = discount(count) * count / ctotal
+                self._store_observed((context, word), prob)
+                used += prob
+                remaining_lower -= lower.get(word, 0.0)
+
+            beta = max(1.0 - used, 0.0)  # mass reserved for unseen words
+            if remaining_lower > 1e-12:
+                self._backoff[context] = beta / remaining_lower
+            else:
+                self._backoff[context] = 0.0
+
+        self._unknown_context_weight = 1.0
+        self._finalize(lower, len(unigram))
+
+
+class StupidBackoff(BigramBackoff):
+    """Stupid Back-off bigram scoring.
+
+    A deliberately simple, unnormalized scheme introduced by Brants et al. (2007)
+    for web-scale language modeling. An observed bigram scores its relative
+    frequency; an unseen bigram scores a fixed weight ``alpha`` times the
+    lower-order unigram score:
+
+    ``S(word | context) = c(context, word) / c(context)``   if observed,
+
+    ``S(word | context) = alpha * P_uni(word)``    otherwise.
+
+    Because it skips the normalization Katz back-off performs, the scores do not
+    form a probability distribution (they do not sum to one), but they are very
+    cheap to compute and work well for ranking when data is plentiful.
+
+    Args:
+        freqdist: Frequency distribution mapping ``(context, word)`` bigrams to
+            counts. Non-bigram keys are ignored.
+        alpha: Back-off weight applied when falling back to the unigram model.
+            Defaults to ``0.4`` (the value recommended by Brants et al.).
+        logprob: Return log-scores if ``True`` (the default), otherwise plain
+            scores.
+
+    Examples:
+        Observed bigrams score their relative frequency; unseen bigrams are
+        penalized by ``alpha`` and scored from the unigram model:
+
+        >>> bigram_counts = {
+        ...     ("the", "cat"): 5, ("the", "dog"): 3, ("a", "cat"): 2,
+        ...     ("a", "dog"): 1, ("big", "cat"): 1, ("small", "dog"): 1,
+        ... }
+        >>> sb = StupidBackoff(bigram_counts, logprob=False)
+        >>> round(sb(("the", "cat")), 3)      # 5 / 8
+        0.625
+        >>> round(sb(("a", "dog")), 3)        # 1 / 3
+        0.333
+        >>> round(sb(("big", "dog")), 3)      # 0.4 * P_uni("dog")
+        0.154
+
+    Note:
+        Stupid Back-off returns *scores*, not normalized probabilities, so
+        metrics that assume a valid distribution (such as perplexity) are not
+        meaningful here. Use it for ranking and comparison, where only the
+        relative ordering of scores matters.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        freqdist: FrequencyDistribution,
+        alpha: float = 0.4,
+        logprob: bool = True,
+    ) -> None:
+        """Initialize Stupid Back-off scoring."""
+        if not 0 < alpha <= 1:
+            raise ValueError("Back-off weight alpha must be in (0, 1]")
+
+        config = StupidBackoffConfig(alpha=alpha, logprob=logprob)
+        super().__init__(config)
+        self.name = "Stupid Back-off"
+        self.fit(freqdist)
+
+    def _compute_probabilities(self, freqdist: FrequencyDistribution) -> None:
+        """Compute Stupid Back-off scores."""
+        alpha = self.config.alpha  # type: ignore[attr-defined]
+
+        context_total, _context_types, context_word, unigram, total = extract_bigram_stats(freqdist)
+
+        lower = {word: count / total for word, count in unigram.items()} if total else {}
+
+        for (context, word), count in context_word.items():
+            ctotal = context_total[context]
+            self._store_observed((context, word), count / ctotal)
+
+        # Every context (seen or unseen) uses the same alpha weight, so leave
+        # self._backoff empty and let the unknown-context weight handle both.
+        self._unknown_context_weight = alpha
+
+        vocab_size = len(unigram)
+        self._lower = lower
+        fallback = alpha / vocab_size if vocab_size else 1e-10
+        self._unobs = math.log(fallback) if self.logprob else fallback

--- a/src/freqprob/methods/discounting.py
+++ b/src/freqprob/methods/discounting.py
@@ -1,0 +1,212 @@
+"""Absolute-discounting and Pitman-Yor bigram smoothing.
+
+Both methods discount observed bigram counts and interpolate with a lower-order
+unigram model. Absolute discounting subtracts a fixed amount from every count;
+Pitman-Yor generalizes it with a second (concentration) parameter and has
+absolute discounting as its ``strength = 0`` special case.
+"""
+
+from dataclasses import dataclass
+
+from freqprob.base import FrequencyDistribution, ScoringMethodConfig
+from freqprob.methods._bigram import BigramBackoff, extract_bigram_stats
+
+
+@dataclass
+class DiscountingConfig(ScoringMethodConfig):
+    """Configuration for absolute-discounting / Pitman-Yor smoothing.
+
+    Attributes:
+        discount: Amount subtracted from each observed count (the ``d``
+            parameter). ``0 <= discount < 1``.
+        strength: Pitman-Yor concentration parameter ``theta`` (``theta >
+            -discount``). ``0`` recovers absolute discounting.
+    """
+
+    discount: float = 0.75
+    strength: float = 0.0
+
+
+class AbsoluteDiscounting(BigramBackoff):
+    """Absolute-discounting bigram smoothing.
+
+    Subtracts a fixed discount ``d`` from every observed bigram count and
+    redistributes the freed mass to a lower-order unigram model. For a bigram
+    ``(context, word)`` with count ``c`` and context total ``C``,
+
+    ``P(word | context) = max(c - d, 0) / C + (d * N1+(context) / C) * P_uni(word)``
+
+    where ``N1+(context)`` is the number of distinct words seen after the
+    context and ``P_uni`` is the unigram maximum-likelihood distribution. This is
+    the classic Ney-Essen-Kneser discounting scheme and the foundation Kneser-Ney
+    builds on — the difference is that Kneser-Ney replaces ``P_uni`` with a
+    continuation distribution. Reach for absolute discounting when you want simple,
+    well-understood discounting without Kneser-Ney's continuation weighting.
+
+    Args:
+        freqdist: Frequency distribution mapping ``(context, word)`` bigrams to
+            counts. Non-bigram keys are ignored.
+        discount: Absolute discounting parameter ``0 <= d < 1``. Common values
+            are ``0.5``-``0.8``. Defaults to ``0.75``.
+        logprob: Return log-probabilities if ``True`` (the default), otherwise
+            plain probabilities.
+
+    Examples:
+        Observed bigrams are discounted and interpolated with the unigram model,
+        while unseen bigrams back off to it:
+
+        >>> bigram_counts = {
+        ...     ("the", "cat"): 5, ("the", "dog"): 3, ("a", "cat"): 2,
+        ...     ("a", "dog"): 1, ("big", "cat"): 1, ("small", "dog"): 1,
+        ... }
+        >>> ad = AbsoluteDiscounting(bigram_counts, discount=0.75, logprob=False)
+        >>> round(ad(("the", "cat")), 3)
+        0.647
+        >>> round(ad(("a", "cat")), 3)
+        0.724
+        >>> round(ad(("big", "dog")), 3)      # unseen word in a known context
+        0.288
+        >>> round(ad(("new", "cat")), 3)      # unseen context backs off to unigram
+        0.615
+
+    Note:
+        This implementation assumes bigram input. Unlike Kneser-Ney it uses raw
+        unigram frequencies for the lower-order model, so a frequent word keeps
+        its weight even if it appears in few distinct contexts.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        freqdist: FrequencyDistribution,
+        discount: float = 0.75,
+        logprob: bool = True,
+    ) -> None:
+        """Initialize absolute-discounting smoothing."""
+        if not 0 <= discount < 1:
+            raise ValueError("Discount parameter must be in [0, 1)")
+
+        config = DiscountingConfig(discount=discount, strength=0.0, logprob=logprob)
+        super().__init__(config)
+        self.name = "Absolute Discounting"
+        self.fit(freqdist)
+
+    def _compute_probabilities(self, freqdist: FrequencyDistribution) -> None:
+        """Compute absolute-discounting probabilities."""
+        discount = self.config.discount  # type: ignore[attr-defined]
+
+        context_total, context_types, context_word, unigram, total = extract_bigram_stats(freqdist)
+
+        lower = {word: count / total for word, count in unigram.items()} if total else {}
+
+        for context, ctotal in context_total.items():
+            n1_plus = len(context_types[context])
+            self._backoff[context] = discount * n1_plus / ctotal
+
+        for (context, word), count in context_word.items():
+            ctotal = context_total[context]
+            main = max(count - discount, 0.0) / ctotal
+            prob = main + self._backoff[context] * lower.get(word, 0.0)
+            self._store_observed((context, word), prob)
+
+        self._unknown_context_weight = 1.0
+        self._finalize(lower, len(unigram))
+
+
+class PitmanYor(BigramBackoff):
+    """Pitman-Yor process bigram smoothing.
+
+    A two-parameter generalization of absolute discounting based on the
+    Pitman-Yor process. With discount ``d`` and concentration (strength)
+    ``theta``, an observed bigram ``(context, word)`` with count ``c``, context
+    total ``C``, and ``t`` distinct words seen after the context scores
+
+    ``P(word | context) = (c - d + (theta + d * t) * P_uni(word)) / (theta + C)``
+
+    and a word unseen in the context gets ``(theta + d * t) / (theta + C) *
+    P_uni(word)``. The concentration ``theta`` controls how much mass is reserved
+    for the base distribution independently of the discount: ``theta = 0``
+    recovers absolute discounting, while larger ``theta`` pulls estimates toward
+    the unigram model. Pitman-Yor priors match the power-law behavior of natural
+    language and are the basis of the hierarchical Pitman-Yor language model,
+    which subsumes Kneser-Ney as a special case.
+
+    Args:
+        freqdist: Frequency distribution mapping ``(context, word)`` bigrams to
+            counts. Non-bigram keys are ignored.
+        discount: Discount parameter ``0 <= d < 1``. Defaults to ``0.75``.
+        strength: Concentration parameter ``theta > -discount``. Defaults to
+            ``1.0``. ``0`` recovers absolute discounting.
+        logprob: Return log-probabilities if ``True`` (the default), otherwise
+            plain probabilities.
+
+    Examples:
+        Larger counts still dominate, but the concentration parameter reserves
+        extra mass for the unigram base distribution:
+
+        >>> bigram_counts = {
+        ...     ("the", "cat"): 5, ("the", "dog"): 3, ("a", "cat"): 2,
+        ...     ("a", "dog"): 1, ("big", "cat"): 1, ("small", "dog"): 1,
+        ... }
+        >>> py = PitmanYor(bigram_counts, discount=0.75, strength=1.0, logprob=False)
+        >>> round(py(("the", "cat")), 3)
+        0.643
+        >>> round(py(("a", "cat")), 3)
+        0.697
+        >>> round(py(("big", "dog")), 3)      # unseen word in a known context
+        0.337
+        >>> round(py(("new", "cat")), 3)      # unseen context backs off to unigram
+        0.615
+
+    Note:
+        This implementation is a single-level (bigram) Pitman-Yor model using the
+        unigram maximum-likelihood distribution as its base measure and the
+        number of observed types as the table count. It is a practical
+        approximation of the full hierarchical Pitman-Yor process.
+    """
+
+    __slots__ = ()
+
+    def __init__(
+        self,
+        freqdist: FrequencyDistribution,
+        discount: float = 0.75,
+        strength: float = 1.0,
+        logprob: bool = True,
+    ) -> None:
+        """Initialize Pitman-Yor smoothing."""
+        if not 0 <= discount < 1:
+            raise ValueError("Discount parameter must be in [0, 1)")
+        if strength <= -discount:
+            raise ValueError("Strength parameter must be greater than -discount")
+
+        config = DiscountingConfig(discount=discount, strength=strength, logprob=logprob)
+        super().__init__(config)
+        self.name = "Pitman-Yor"
+        self.fit(freqdist)
+
+    def _compute_probabilities(self, freqdist: FrequencyDistribution) -> None:
+        """Compute Pitman-Yor probabilities."""
+        discount = self.config.discount  # type: ignore[attr-defined]
+        strength = self.config.strength  # type: ignore[attr-defined]
+
+        context_total, context_types, context_word, unigram, total = extract_bigram_stats(freqdist)
+
+        lower = {word: count / total for word, count in unigram.items()} if total else {}
+
+        for context, ctotal in context_total.items():
+            num_types = len(context_types[context])
+            self._backoff[context] = (strength + discount * num_types) / (strength + ctotal)
+
+        for (context, word), count in context_word.items():
+            ctotal = context_total[context]
+            num_types = len(context_types[context])
+            numerator = (count - discount) + (strength + discount * num_types) * lower.get(
+                word, 0.0
+            )
+            prob = numerator / (strength + ctotal)
+            self._store_observed((context, word), prob)
+
+        self._unknown_context_weight = 1.0
+        self._finalize(lower, len(unigram))

--- a/src/freqprob/methods/interpolated.py
+++ b/src/freqprob/methods/interpolated.py
@@ -317,3 +317,153 @@ class Interpolated(ScoringMethod):
             self._unobs = math.log(interpolated_unseen)
         else:
             self._unobs = interpolated_unseen
+
+
+def _mle(dist: FrequencyDistribution) -> tuple[dict[Element, float], int]:
+    """Return the maximum-likelihood distribution and total count of ``dist``."""
+    total = sum(dist.values())
+    if total == 0:
+        return {}, 0
+    return {element: count / total for element, count in dist.items()}, total
+
+
+def _estimate_jm_lambda(
+    high_order_dist: FrequencyDistribution,
+    low_order_dist: FrequencyDistribution,
+    held_out_dist: FrequencyDistribution,
+    low_order_n: int | None,
+    init_lambda: float,
+    iterations: int,
+) -> float:
+    """Estimate the Jelinek-Mercer weight by EM (deleted interpolation).
+
+    Iteratively reweights ``lambda`` so that the interpolated model
+    ``lambda * P_high + (1 - lambda) * P_low`` maximizes the likelihood of the
+    held-out data. Returns ``init_lambda`` unchanged when there is no usable
+    held-out evidence.
+    """
+    high_probs, _ = _mle(high_order_dist)
+    low_probs, _ = _mle(low_order_dist)
+
+    # Precompute (p_high, p_low, count) for each held-out n-gram once.
+    observations: list[tuple[float, float, float]] = []
+    for ngram, count in held_out_dist.items():
+        if count <= 0:
+            continue
+        p_high = high_probs.get(ngram, 0.0)
+        if low_order_n is not None and isinstance(ngram, tuple) and len(ngram) >= low_order_n:
+            context: Element = ngram[-low_order_n:]
+        else:
+            context = ngram
+        p_low = low_probs.get(context, 0.0)
+        if p_high <= 0.0 and p_low <= 0.0:
+            continue
+        observations.append((p_high, p_low, float(count)))
+
+    if not observations:
+        return init_lambda
+
+    lam = init_lambda
+    for _ in range(iterations):
+        expected_high = 0.0
+        total = 0.0
+        for p_high, p_low, weight in observations:
+            denom = lam * p_high + (1 - lam) * p_low
+            if denom <= 0.0:
+                continue
+            responsibility = lam * p_high / denom
+            expected_high += weight * responsibility
+            total += weight
+        if total <= 0.0:
+            break
+        lam = expected_high / total
+    return lam
+
+
+class JelinekMercer(Interpolated):
+    """Jelinek-Mercer smoothing with an EM-estimated interpolation weight.
+
+    Jelinek-Mercer smoothing linearly interpolates a higher-order model with a
+    lower-order one, exactly as :class:`Interpolated` does, but chooses the
+    interpolation weight ``lambda`` by *deleted interpolation*: given a held-out
+    distribution, the weight is fitted with the Expectation-Maximization
+    algorithm to maximize the likelihood of that held-out data. Without held-out
+    data it behaves as fixed-weight interpolation using ``lambda_weight``.
+
+    Args:
+        high_order_dist: Higher-order frequency distribution (e.g. trigrams).
+        low_order_dist: Lower-order frequency distribution (e.g. bigrams).
+        held_out_dist: Optional held-out frequency distribution used to fit
+            ``lambda`` by EM. If ``None`` (the default), the supplied
+            ``lambda_weight`` is used unchanged.
+        lambda_weight: Interpolation weight ``0 <= lambda_weight <= 1`` for the
+            high-order model. Used directly when there is no held-out data, and
+            as the EM starting point otherwise. Defaults to ``0.5``.
+        em_iterations: Number of EM iterations when fitting ``lambda`` from
+            held-out data (a positive integer). Defaults to ``10``.
+        logprob: Return log-probabilities if ``True`` (the default), otherwise
+            plain probabilities.
+
+    Attributes:
+        estimated_lambda: The interpolation weight actually used — either the
+            EM-fitted value or ``lambda_weight`` when no held-out data was given.
+
+    Examples:
+        With no held-out data the estimated weight is exactly ``lambda_weight``,
+        and scoring matches fixed-weight interpolation:
+
+        >>> trigrams = {("the", "big", "cat"): 3, ("a", "big", "dog"): 2}
+        >>> bigrams = {("big", "cat"): 5, ("big", "dog"): 3}
+        >>> jm = JelinekMercer(trigrams, bigrams, lambda_weight=0.6, logprob=False)
+        >>> round(jm.estimated_lambda, 2)
+        0.6
+        >>> round(jm(("the", "big", "cat")), 3)   # 0.6 * (3/5) + 0.4 * (5/8)
+        0.61
+
+        Held-out data that the high-order model predicts well pulls the weight up:
+
+        >>> held_out = {("the", "big", "cat"): 8, ("a", "big", "dog"): 6}
+        >>> jm = JelinekMercer(trigrams, bigrams, held_out_dist=held_out, logprob=False)
+        >>> jm.estimated_lambda > 0.5
+        True
+
+    Note:
+        EM fits a single global ``lambda`` (not the per-context bucketed weights
+        of the original Jelinek-Mercer scheme). The held-out data should be
+        disjoint from the training data for the estimate to be meaningful.
+    """
+
+    __slots__ = ("em_iterations", "estimated_lambda")
+
+    def __init__(
+        self,
+        high_order_dist: FrequencyDistribution,
+        low_order_dist: FrequencyDistribution,
+        held_out_dist: FrequencyDistribution | None = None,
+        lambda_weight: float = 0.5,
+        em_iterations: int = 10,
+        logprob: bool = True,
+    ) -> None:
+        """Initialize Jelinek-Mercer smoothing, fitting ``lambda`` if held-out data is given."""
+        if not 0 <= lambda_weight <= 1:
+            raise ValueError("Lambda weight must be between 0 and 1")
+        if em_iterations < 1:
+            raise ValueError("em_iterations must be a positive integer")
+
+        low_order_n = self._detect_order(low_order_dist)
+        if held_out_dist:
+            estimated = _estimate_jm_lambda(
+                high_order_dist,
+                low_order_dist,
+                held_out_dist,
+                low_order_n,
+                lambda_weight,
+                em_iterations,
+            )
+        else:
+            estimated = lambda_weight
+
+        super().__init__(high_order_dist, low_order_dist, lambda_weight=estimated, logprob=logprob)
+        self.name = "Jelinek-Mercer"
+        self.em_iterations = em_iterations
+        self.estimated_lambda = estimated

--- a/src/freqprob/metrics.py
+++ b/src/freqprob/metrics.py
@@ -1,9 +1,19 @@
-"""Model-evaluation metrics: perplexity, cross-entropy, KL divergence."""
+"""Model-evaluation metrics: perplexity, cross-entropy, KL divergence, entropy.
+
+Alongside the model-scoring metrics, this module provides sample-based estimators
+that work directly on a frequency distribution: :func:`sample_coverage` (the
+Good-Turing estimate of observed mass) and the bias-corrected entropy estimators
+:func:`chao_shen_entropy` and :func:`nsb_entropy`, which correct the downward bias
+of the naive plug-in entropy when many types are rare or unobserved.
+"""
 
 import math
 from collections.abc import Iterable
 
-from .base import Element, ScoringMethod
+import numpy as np
+from scipy.special import gammaln, polygamma, psi
+
+from .base import Element, FrequencyDistribution, ScoringMethod
 
 
 def perplexity(model: ScoringMethod, test_data: Iterable[Element]) -> float:
@@ -162,3 +172,174 @@ def model_comparison(
         }
 
     return results
+
+
+def sample_coverage(freqdist: FrequencyDistribution) -> float:
+    """Estimate the proportion of total probability mass that was observed.
+
+    Uses the Good-Turing estimator of the *missing mass*: the share of
+    probability belonging to unseen types is approximately ``N1 / N``, where
+    ``N1`` is the number of types seen exactly once (singletons) and ``N`` the
+    total number of observations. Coverage is the complement, ``1 - N1 / N``.
+
+    Args:
+        freqdist: Mapping of elements to observed counts.
+
+    Returns:
+        The estimated observed mass, in ``[0, 1]``. Returns ``0.0`` for an empty
+        distribution.
+
+    Examples:
+        >>> from freqprob import sample_coverage
+        >>> sample_coverage({"a": 10, "b": 5, "c": 3})  # no singletons
+        1.0
+        >>> round(sample_coverage({"a": 8, "b": 1, "c": 1}), 3)  # two singletons of 10
+        0.8
+    """
+    total = sum(freqdist.values())
+    if total == 0:
+        return 0.0
+    n1 = sum(1 for count in freqdist.values() if count == 1)
+    return 1.0 - n1 / total
+
+
+def chao_shen_entropy(freqdist: FrequencyDistribution) -> float:
+    """Estimate Shannon entropy with the Chao-Shen bias correction.
+
+    The naive plug-in entropy underestimates the true entropy when the sample
+    misses probability mass. The Chao-Shen estimator combines Good-Turing
+    coverage adjustment with a Horvitz-Thompson correction for unseen types,
+    which reduces this bias:
+
+    ``H = - sum_i (C p_i) log(C p_i) / (1 - (1 - C p_i) ** N)``
+
+    where ``p_i`` is the relative frequency of type ``i``, ``C`` the sample
+    coverage (see :func:`sample_coverage`), and ``N`` the total count.
+
+    Args:
+        freqdist: Mapping of elements to observed counts.
+
+    Returns:
+        The estimated entropy in nats (natural log). Returns ``0.0`` for an
+        empty distribution or when coverage is zero (all singletons).
+
+    Examples:
+        >>> from freqprob import chao_shen_entropy
+        >>> import math
+        >>> # Approaches the true entropy of a uniform distribution when well sampled.
+        >>> round(chao_shen_entropy({"a": 1000, "b": 1000, "c": 1000}), 3)
+        1.099
+        >>> round(math.log(3), 3)
+        1.099
+    """
+    total = sum(freqdist.values())
+    if total == 0:
+        return 0.0
+    n1 = sum(1 for count in freqdist.values() if count == 1)
+    coverage = 1.0 - n1 / total
+    if coverage <= 0.0:
+        return 0.0
+
+    entropy = 0.0
+    for count in freqdist.values():
+        if count <= 0:
+            continue
+        p = coverage * (count / total)
+        if p <= 0.0:
+            continue
+        inclusion = 1.0 - (1.0 - p) ** total
+        if inclusion <= 0.0:
+            continue
+        entropy -= p * math.log(p) / inclusion
+    return entropy
+
+
+def nsb_entropy(freqdist: FrequencyDistribution, bins: int | None = None) -> float:
+    """Estimate Shannon entropy with the Nemenman-Shafee-Bialek estimator.
+
+    The NSB estimator is a Bayesian entropy estimator that averages the posterior
+    mean entropy of a symmetric Dirichlet model over its concentration parameter,
+    using a prior chosen so the *a priori* entropy is (nearly) uniform. It is
+    well suited to the undersampled regime, where the number of possible types is
+    comparable to or larger than the number of observations.
+
+    Args:
+        freqdist: Mapping of elements to observed counts.
+        bins: The size of the assumed alphabet (number of possible types),
+            reserving entropy for types that could occur but were not seen. If
+            ``None`` (the default), the number of observed types is used, so no
+            unseen types are assumed. Must be at least the number of observed
+            types.
+
+    Returns:
+        The estimated entropy in nats (natural log), in ``[0, log(bins)]``.
+        Returns ``0.0`` for an empty distribution or a single possible type.
+
+    Raises:
+        ValueError: If ``bins`` is smaller than the number of observed types.
+
+    Examples:
+        >>> from freqprob import nsb_entropy
+        >>> import math
+        >>> # Well-sampled uniform distribution approaches log(K).
+        >>> round(nsb_entropy({"a": 500, "b": 500, "c": 500, "d": 500}), 2)
+        1.39
+        >>> round(math.log(4), 2)
+        1.39
+    """
+    counts = [int(count) for count in freqdist.values() if count > 0]
+    n_observed_types = len(counts)
+
+    if bins is None:
+        bins = n_observed_types
+    if bins < n_observed_types:
+        raise ValueError("bins must be at least the number of observed types")
+
+    total = sum(counts)
+    if total == 0 or bins <= 1:
+        return 0.0
+
+    k = float(bins)
+    n = float(total)
+    observed = np.asarray(counts, dtype=float)
+
+    # Integrate over the per-bin Dirichlet concentration parameter ``a`` on a
+    # geometric grid, weighting each value by the evidence and the prior that
+    # makes the a-priori mean entropy uniform.
+    a = np.geomspace(1e-8, 1e8, 6000)
+    ka = k * a
+
+    # Log evidence (unnormalized): unobserved bins contribute nothing in log.
+    log_evidence = gammaln(ka) - gammaln(n + ka)
+    for count in observed:
+        log_evidence = log_evidence + gammaln(count + a) - gammaln(a)
+
+    # Prior Jacobian d(xi)/da, where xi(a) = psi(k a + 1) - psi(a + 1) is the
+    # a-priori mean entropy; a flat prior on xi makes this the density in ``a``.
+    jacobian = k * polygamma(1, ka + 1.0) - polygamma(1, a + 1.0)
+    jacobian = np.clip(jacobian, 0.0, None)
+
+    # Posterior mean entropy given ``a`` (Wolpert & Wolf, 1995).
+    denom = n + ka
+    observed_term = np.zeros_like(a)
+    for count in observed:
+        observed_term = observed_term + (count + a) * psi(count + a + 1.0)
+    unobserved_term = (k - n_observed_types) * a * psi(a + 1.0)
+    mean_entropy = psi(denom + 1.0) - (observed_term + unobserved_term) / denom
+
+    # Combine in log space; weight = evidence * jacobian * grid spacing.
+    spacing = np.gradient(a)
+    with np.errstate(divide="ignore"):
+        log_weight = log_evidence + np.log(np.where(jacobian > 0, jacobian, 1.0)) + np.log(spacing)
+    log_weight = np.where(jacobian > 0, log_weight, -np.inf)
+
+    finite = np.isfinite(log_weight)
+    if not finite.any():
+        return 0.0
+    log_weight = log_weight - np.max(log_weight[finite])
+    weight = np.where(finite, np.exp(log_weight), 0.0)
+
+    normalizer = float(np.sum(weight))
+    if normalizer <= 0.0:
+        return 0.0
+    return float(np.sum(weight * mean_entropy) / normalizer)

--- a/tests/test_new_methods.py
+++ b/tests/test_new_methods.py
@@ -1,0 +1,257 @@
+"""Tests for the back-off / discounting smoothers and the entropy estimators.
+
+Covers ``AbsoluteDiscounting``, ``PitmanYor``, ``KatzBackoff``,
+``StupidBackoff``, and ``JelinekMercer``, plus the ``sample_coverage``,
+``chao_shen_entropy``, and ``nsb_entropy`` functions added to ``metrics``.
+"""
+
+import math
+
+import pytest
+
+from freqprob import (
+    AbsoluteDiscounting,
+    JelinekMercer,
+    KatzBackoff,
+    PitmanYor,
+    StupidBackoff,
+    chao_shen_entropy,
+    nsb_entropy,
+    sample_coverage,
+)
+from freqprob.base import Element, ScoringMethod
+
+# Bigram data with a spread of low counts, suitable for every method here.
+BIGRAM_DATA: dict[Element, int] = {
+    ("the", "cat"): 5,
+    ("the", "dog"): 3,
+    ("the", "bird"): 2,
+    ("a", "cat"): 2,
+    ("a", "dog"): 1,
+    ("a", "bird"): 1,
+    ("big", "cat"): 1,
+    ("small", "dog"): 1,
+    ("my", "fish"): 1,
+    ("your", "fish"): 1,
+}
+
+
+# --------------------------------------------------------------------------- #
+# Absolute Discounting
+# --------------------------------------------------------------------------- #
+def test_absolute_discounting_basic() -> None:
+    """Observed bigrams get sensible probabilities; unseen ones stay positive."""
+    ad = AbsoluteDiscounting(BIGRAM_DATA, discount=0.75, logprob=False)
+    p_the_cat = ad(("the", "cat"))
+    p_the_dog = ad(("the", "dog"))
+    assert 0 < p_the_dog < p_the_cat < 1
+    # Unseen word in a known context still backs off to the unigram model.
+    assert ad(("the", "fish")) > 0
+    # Unseen context backs off to the raw unigram probability of the word.
+    assert ad(("brand", "cat")) == pytest.approx(8 / 18)
+
+
+def test_absolute_discounting_logprob_matches() -> None:
+    """Log-probabilities are the logs of the plain probabilities."""
+    ad_p = AbsoluteDiscounting(BIGRAM_DATA, logprob=False)
+    ad_l = AbsoluteDiscounting(BIGRAM_DATA, logprob=True)
+    for query in [("the", "cat"), ("a", "dog"), ("the", "fish"), ("x", "cat")]:
+        assert ad_l(query) == pytest.approx(math.log(ad_p(query)))
+
+
+def test_absolute_discounting_validation() -> None:
+    """Discount must be in [0, 1)."""
+    with pytest.raises(ValueError, match="Discount"):
+        AbsoluteDiscounting(BIGRAM_DATA, discount=1.0)
+    with pytest.raises(ValueError, match="Discount"):
+        AbsoluteDiscounting(BIGRAM_DATA, discount=-0.1)
+
+
+# --------------------------------------------------------------------------- #
+# Pitman-Yor
+# --------------------------------------------------------------------------- #
+def test_pitman_yor_reduces_to_absolute_discounting() -> None:
+    """With strength=0, Pitman-Yor equals absolute discounting."""
+    ad = AbsoluteDiscounting(BIGRAM_DATA, discount=0.75, logprob=False)
+    py = PitmanYor(BIGRAM_DATA, discount=0.75, strength=0.0, logprob=False)
+    for query in [("the", "cat"), ("a", "dog"), ("the", "fish"), ("z", "bird")]:
+        assert py(query) == pytest.approx(ad(query))
+
+
+def test_pitman_yor_strength_shifts_mass() -> None:
+    """A larger strength pulls a frequent-context estimate toward the base."""
+    py_low = PitmanYor(BIGRAM_DATA, discount=0.5, strength=0.0, logprob=False)
+    py_high = PitmanYor(BIGRAM_DATA, discount=0.5, strength=10.0, logprob=False)
+    # 'the cat' is well attested, so more concentration lowers its estimate.
+    assert py_high(("the", "cat")) < py_low(("the", "cat"))
+
+
+def test_pitman_yor_validation() -> None:
+    """Discount in [0, 1) and strength > -discount."""
+    with pytest.raises(ValueError, match="Discount"):
+        PitmanYor(BIGRAM_DATA, discount=1.0)
+    with pytest.raises(ValueError, match="Strength"):
+        PitmanYor(BIGRAM_DATA, discount=0.5, strength=-0.5)
+
+
+# --------------------------------------------------------------------------- #
+# Katz Back-off
+# --------------------------------------------------------------------------- #
+def test_katz_backoff_basic() -> None:
+    """Observed bigrams are (at most) their MLE; unseen ones back off."""
+    katz = KatzBackoff(BIGRAM_DATA, logprob=False)
+    # Discounting never increases an observed probability above its MLE.
+    assert katz(("the", "cat")) <= 5 / 10 + 1e-9
+    assert katz(("the", "cat")) > 0
+    # Unseen word in a known context is non-negative and finite.
+    assert katz(("the", "fish")) >= 0
+
+
+def test_katz_backoff_validation() -> None:
+    """Threshold k must be a positive integer."""
+    with pytest.raises(ValueError, match="k"):
+        KatzBackoff(BIGRAM_DATA, k=0)
+
+
+# --------------------------------------------------------------------------- #
+# Stupid Back-off
+# --------------------------------------------------------------------------- #
+def test_stupid_backoff_scores() -> None:
+    """Observed bigrams score their MLE; unseen ones are alpha * unigram."""
+    sb = StupidBackoff(BIGRAM_DATA, alpha=0.4, logprob=False)
+    assert sb(("the", "cat")) == pytest.approx(5 / 10)
+    assert sb(("a", "dog")) == pytest.approx(1 / 4)
+    # 'the fish' unseen: alpha * P_uni(fish) = 0.4 * (2 / 18)
+    assert sb(("the", "fish")) == pytest.approx(0.4 * (2 / 18))
+
+
+def test_stupid_backoff_validation() -> None:
+    """Alpha must be in (0, 1]."""
+    with pytest.raises(ValueError, match="alpha"):
+        StupidBackoff(BIGRAM_DATA, alpha=0.0)
+    with pytest.raises(ValueError, match="alpha"):
+        StupidBackoff(BIGRAM_DATA, alpha=1.5)
+
+
+# --------------------------------------------------------------------------- #
+# Jelinek-Mercer
+# --------------------------------------------------------------------------- #
+TRIGRAMS: dict[Element, int] = {
+    ("the", "big", "cat"): 3,
+    ("a", "big", "dog"): 2,
+    ("the", "big", "dog"): 1,
+}
+BIGRAMS: dict[Element, int] = {("big", "cat"): 5, ("big", "dog"): 3, ("small", "cat"): 2}
+
+
+def test_jelinek_mercer_without_heldout_is_fixed_lambda() -> None:
+    """With no held-out data it matches the supplied lambda exactly."""
+    jm = JelinekMercer(TRIGRAMS, BIGRAMS, lambda_weight=0.6, logprob=False)
+    assert jm.estimated_lambda == pytest.approx(0.6)
+
+
+def test_jelinek_mercer_em_moves_lambda() -> None:
+    """Held-out data that only high-order predicts pushes lambda toward 1."""
+    held_out: dict[Element, int] = {("the", "big", "cat"): 10, ("a", "big", "dog"): 8}
+    jm = JelinekMercer(TRIGRAMS, BIGRAMS, held_out_dist=held_out, lambda_weight=0.5)
+    assert 0.0 <= jm.estimated_lambda <= 1.0
+    assert jm.estimated_lambda > 0.5
+
+
+def test_jelinek_mercer_validation() -> None:
+    """Lambda in [0, 1] and positive iteration count."""
+    with pytest.raises(ValueError, match="Lambda"):
+        JelinekMercer(TRIGRAMS, BIGRAMS, lambda_weight=1.5)
+    with pytest.raises(ValueError, match="em_iterations"):
+        JelinekMercer(TRIGRAMS, BIGRAMS, em_iterations=0)
+
+
+# --------------------------------------------------------------------------- #
+# Serialization round-trip for the new estimators
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "scorer",
+    [
+        AbsoluteDiscounting(BIGRAM_DATA, logprob=True),
+        PitmanYor(BIGRAM_DATA, logprob=True),
+        KatzBackoff(BIGRAM_DATA, logprob=True),
+        StupidBackoff(BIGRAM_DATA, logprob=True),
+    ],
+)
+def test_backoff_methods_pickle_round_trip(scorer: ScoringMethod) -> None:
+    """Every new bigram scorer survives a save/load round-trip."""
+    import pickle
+
+    restored = pickle.loads(pickle.dumps(scorer))
+    for query in [("the", "cat"), ("the", "fish"), ("new", "cat")]:
+        assert restored(query) == pytest.approx(scorer(query))
+
+
+# --------------------------------------------------------------------------- #
+# sample_coverage
+# --------------------------------------------------------------------------- #
+def test_sample_coverage() -> None:
+    """Coverage is 1 - N1/N and the missing mass is its complement."""
+    no_singletons: dict[Element, int] = {"a": 10, "b": 5, "c": 3}
+    some_singletons: dict[Element, int] = {"a": 8, "b": 1, "c": 1}
+    all_singletons: dict[Element, int] = {"a": 1, "b": 1, "c": 1}
+    empty: dict[Element, int] = {}
+    assert sample_coverage(no_singletons) == 1.0
+    assert sample_coverage(some_singletons) == pytest.approx(0.8)
+    assert sample_coverage(empty) == 0.0
+    # All singletons -> zero coverage (all mass is missing).
+    assert sample_coverage(all_singletons) == pytest.approx(0.0)
+
+
+# --------------------------------------------------------------------------- #
+# chao_shen_entropy
+# --------------------------------------------------------------------------- #
+def test_chao_shen_entropy_bounds_and_bias() -> None:
+    """Chao-Shen is non-negative and corrects the plug-in bias upward."""
+    freqdist: dict[Element, int] = {"a": 8, "b": 1, "c": 1}
+    empty: dict[Element, int] = {}
+    single: dict[Element, int] = {"a": 1}
+    plugin = -sum((c / 10) * math.log(c / 10) for c in freqdist.values())
+    cs = chao_shen_entropy(freqdist)
+    assert cs > plugin  # bias-corrected estimate is larger
+    assert chao_shen_entropy(empty) == 0.0
+    # A single observation has zero entropy.
+    assert chao_shen_entropy(single) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_chao_shen_matches_plugin_when_well_sampled() -> None:
+    """With no singletons and large counts it approaches the true entropy."""
+    freqdist: dict[Element, int] = {"a": 1000, "b": 1000, "c": 1000}
+    assert chao_shen_entropy(freqdist) == pytest.approx(math.log(3), abs=1e-3)
+
+
+# --------------------------------------------------------------------------- #
+# nsb_entropy
+# --------------------------------------------------------------------------- #
+def test_nsb_entropy_limits() -> None:
+    """NSB approaches ln K for a well-sampled uniform distribution."""
+    uniform: dict[Element, int] = {chr(97 + i): 500 for i in range(4)}
+    peaked: dict[Element, int] = {"a": 10000, "b": 1, "c": 1}
+    empty: dict[Element, int] = {}
+    single: dict[Element, int] = {"a": 5}
+    assert nsb_entropy(uniform) == pytest.approx(math.log(4), abs=1e-2)
+    # Highly peaked distribution -> near-zero entropy.
+    assert nsb_entropy(peaked) < 0.05
+    assert nsb_entropy(empty) == 0.0
+    assert nsb_entropy(single) == 0.0  # single type -> zero entropy
+
+
+def test_nsb_entropy_bins_monotonic() -> None:
+    """A larger assumed alphabet reserves more entropy for unseen types."""
+    freqdist: dict[Element, int] = {"a": 8, "b": 1, "c": 1}
+    small = nsb_entropy(freqdist)  # bins defaults to 3 observed types
+    large = nsb_entropy(freqdist, bins=100)
+    assert large > small
+    assert large <= math.log(100)
+
+
+def test_nsb_entropy_rejects_too_few_bins() -> None:
+    """Bins below the observed type count is an error."""
+    too_few: dict[Element, int] = {"a": 1, "b": 1, "c": 1}
+    with pytest.raises(ValueError, match="bins"):
+        nsb_entropy(too_few, bins=2)


### PR DESCRIPTION
## Summary

Adds a family of new smoothing estimators and sample-based entropy estimators, completing a feature whose implementation files and tests were in the tree but not yet wired up or finished.

### New bigram smoothing methods
Model `P(word | context)` over `(context, word)` distributions, discounting observed bigrams and backing off to a unigram model. Shared machinery lives in `methods/_bigram.py`.

- **`AbsoluteDiscounting`** — subtracts a fixed discount, interpolating with the unigram model (the Ney-Essen-Kneser scheme Kneser-Ney builds on).
- **`PitmanYor`** — two-parameter generalization with a concentration parameter (`strength`); recovers absolute discounting at `strength=0`.
- **`KatzBackoff`** — Good-Turing-discounted, normalized back-off weights (a proper distribution).
- **`StupidBackoff`** — fast, unnormalized scores for ranking at scale (Brants et al. 2007).

### Jelinek-Mercer
- **`JelinekMercer`** — linear interpolation whose weight is fit by EM (deleted interpolation) on a held-out distribution, exposed via `estimated_lambda`; falls back to a fixed weight when no held-out data is given. Implemented as a subclass of `Interpolated`.

### Sample-based entropy estimators (in `metrics`)
- **`sample_coverage`** — Good-Turing estimate of observed probability mass (`1 - N1/N`).
- **`chao_shen_entropy`** — Chao-Shen bias-corrected Shannon entropy.
- **`nsb_entropy`** — Nemenman-Shafee-Bialek Bayesian entropy estimator, integrating the posterior-mean entropy over the Dirichlet concentration parameter (uses the existing `scipy` dependency), with an optional `bins` for the assumed alphabet size.

## Wiring & docs
- All new symbols are exported from the top-level `freqprob` namespace (`__all__`).
- Documented in the README method table, new User Guide sections (with runnable examples), and the landing-page methods table. The API reference picks them up from docstrings automatically.
- `CHANGELOG.md` gains an `[Unreleased]` section (these are new public API — a feature addition, distinct from the docs-only `0.6.2`). The version was **not** bumped; that's left for you to decide when cutting the release.

## Verification

- New `tests/test_new_methods.py` (23 tests) covers every estimator and function, including validation, a `logprob` round-trip, pickle round-trips, and the entropy estimators' limiting behavior.
- Full suite: **389 passed, 5 skipped**, coverage **91.38%** (≥ 88% floor). `ruff format`/`check` clean, `mypy` clean, all 68 doctests and the README/User-Guide doc-example blocks execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_