### PR TITLE
release: prepare 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.7.0] - 2026-07-31
+
+Feature release: new smoothing estimators and entropy metrics, together with the
+license/metadata fixes, documentation rebuild, and landing page that had been
+prepared for 0.6.2. Version 0.6.2 was never published, so PyPI goes from 0.6.1
+directly to 0.7.0, which carries all of that work.
 
 ### Added
 
@@ -24,15 +29,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   entropy estimator, with an optional `bins` for the assumed alphabet size).
 - All new estimators and functions are exported from the top-level `freqprob`
   namespace and covered by `tests/test_new_methods.py`.
-
-## [0.6.2] - 2026-07-28
-
-Maintenance release: license/metadata fixes, a full documentation rebuild, and a
-new documentation landing page. No library code or public API changes since
-0.6.1.
-
-### Added
-
 - **Documentation landing page.** The docs site now opens with a dedicated,
   self-contained landing page — a dry, academic layout (neutral palette,
   monochrome figure and code) with a figure illustrating smoothing — served as

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -11,8 +11,8 @@ authors:
   - family-names: Tresoldi
     given-names: Tiago
     email: freqprob@tresoldi.org
-version: 0.6.2
-date-released: 2026-07-28
+version: 0.7.0
+date-released: 2026-07-31
 license: MIT
 repository-code: "https://github.com/tresoldi/freqprob"
 url: "https://github.com/tresoldi/freqprob"

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ If you use FreqProb in academic research, please cite:
   author = {Tresoldi, Tiago},
   title = {FreqProb: A Python library for probability smoothing and frequency-based estimation},
   url = {https://github.com/tresoldi/freqprob},
-  version = {0.6.2},
+  version = {0.7.0},
   year = {2026}
 }
 ```

--- a/overrides/home.html
+++ b/overrides/home.html
@@ -210,7 +210,7 @@ model("elephant")  <span class="c-com"># 0.0001   unobserved, yet non-zero</span
   title   = {FreqProb: A Python library for probability smoothing
              and frequency-based estimation},
   year    = {2026},
-  version = {0.6.2},
+  version = {0.7.0},
   url     = {https://github.com/tresoldi/freqprob}
 }</pre>
     </section>

--- a/src/freqprob/__init__.py
+++ b/src/freqprob/__init__.py
@@ -1,7 +1,7 @@
 """FreqProb: frequency-based probability estimation library."""
 
 # Version of the freqprob package
-__version__ = "0.6.2"
+__version__ = "0.7.0"
 __author__ = "Tiago Tresoldi"
 __email__ = "freqprob@tresoldi.org"
 


### PR DESCRIPTION
## Summary

Prepares the **0.7.0** release. Version 0.6.2 was never tagged or published (PyPI is on 0.6.1), so this folds both the unreleased new-methods work and the 0.6.2 docs/license changes into a single 0.7.0 that carries everything.

## Changes

- **`__version__` → `0.7.0`** in `src/freqprob/__init__.py` (the packaging version is dynamic from this).
- **Citation version → 0.7.0** in the README BibTeX, the landing-page BibTeX, and `CITATION.cff` (`date-released: 2026-07-31`). The citation key stays `tresoldi_freqprob_2026` (year unchanged).
- **CHANGELOG** — consolidated the `[Unreleased]` and `[0.6.2]` sections into one `[0.7.0] - 2026-07-31` section, with a note that 0.6.2 was skipped. Content is unchanged, just regrouped under Added / Fixed / Changed / Removed.

No library code changes — this is release bookkeeping only.

## Verification

`ruff format --check` clean; the doctest and README/User-Guide doc-example harnesses pass; `freqprob.__version__` reports `0.7.0`. No `0.6.2` references remain outside the intentional CHANGELOG note.

## After merge

Tagging `v0.7.0` on the merge commit will publish to PyPI. Because this session's token lacks `workflow` scope, the tag push needs to run outside the session:

```
git fetch origin main && git tag -a v0.7.0 -m "Release 0.7.0" origin/main && git push origin v0.7.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KqmVsfguTXZRSfhTADZjMk)_